### PR TITLE
Use a monospace default font

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -513,7 +513,7 @@ static std::tuple<QString, double, std::uint8_t> parse_guifont(const QString& st
   }
 }
 
-void EditorArea::set_guifont(const QString& new_font)
+void EditorArea::set_guifont(QString new_font)
 {
   // Can take the form
   // <fontname>, <fontname:h<size>, <fontname>:h<size>:b, <fontname>:b,
@@ -521,6 +521,12 @@ void EditorArea::set_guifont(const QString& new_font)
   // for fallback.
   // We want to consider the fonts one at a time so we have to first
   // split the text. The delimiter that signifies a new font is a comma.
+
+  // Neovim sends "" on initialization, but we want a monospace font
+  if (new_font.isEmpty())
+  {
+    new_font = default_font_family();
+  }
   const QStringList lst = new_font.split(",");
   fonts.clear();
   font_for_unicode.clear();

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -391,8 +391,10 @@ protected:
   int cursor_animation_frametime_ms = 10;
   /**
    * Sets the current font to new_font.
+   * If new_font is empty (this indicates an unset value),
+   * uses a default font given by default_font_family() in utils.hpp.
    */
-  void set_guifont(const QString& new_font);
+  void set_guifont(QString new_font);
   /**
    * Adds text to the given grid number at the given row and col number,
    * overwriting the previous text a the position.

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -125,4 +125,18 @@ msgpack::object pack(const T& obj)
   return msgpack::object(obj, z);
 }
 
+/// Thanks Neovim-Qt
+/// https://github.com/equalsraf/neovim-qt/blob/master/src/gui/shellwidget/shellwidget.cpp#L42-L50
+/// Returns a monospace font family.
+inline QString default_font_family()
+{
+#if defined(Q_OS_MAC)
+  return "Courier New";
+#elif defined(Q_OS_WIN)
+  return "Consolas";
+#else
+  return "Monospace";
+#endif
+}
+
 #endif // NVUI_UTILS_HPP


### PR DESCRIPTION
See #32 #28 

If a font value is not set through `set guifont`, nvui uses an unspecified font instead.
We solve this by resolving empty `guifont` requests to a default font family, which should be available on the underlying platform (taken from Neovim-Qt [here](https://github.com/equalsraf/neovim-qt/blob/31c7f6e35d488a557209d1f81afd821bf3b73824/src/gui/shellwidget/shellwidget.cpp#L42-L50)