### PR TITLE
Fix crash on exception 'msgpack::v1::insufficient_bytes'

### DIFF
--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -7,6 +7,7 @@
 #include <QStringBuilder>
 #include <QSvgRenderer>
 #include <QPainter>
+#include <atomic>
 #include <chrono>
 #include <stdexcept>
 #include <optional>
@@ -137,6 +138,12 @@ inline QString default_font_family()
 #else
   return "Monospace";
 #endif
+}
+
+template<typename T>
+void wait_for_value(std::atomic<T>& v, T val)
+{
+  while(v != val) {}
 }
 
 #endif // NVUI_UTILS_HPP

--- a/test/test_nvim_eval.cpp
+++ b/test/test_nvim_eval.cpp
@@ -1,4 +1,5 @@
 #include "nvim.hpp"
+#include "utils.hpp"
 #include <catch2/catch.hpp>
 #include <atomic>
 #include <iostream>
@@ -23,7 +24,7 @@ TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
       REQUIRE(res.as<int>() == 3);
       done = true;
     });
-    std::atomic_wait(&done, true);
+    wait_for_value(done, true);
   }
   SECTION("Can evaluate variables")
   {
@@ -33,7 +34,7 @@ TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
       REQUIRE(res.type == msgpack::type::STR);
       done = true;
     });
-    std::atomic_wait(&done, true);
+    wait_for_value(done, true);
   }
   SECTION("Will send errors in the 'err' parameter")
   {
@@ -43,6 +44,6 @@ TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
       REQUIRE(!err.is_nil());
       done = true;
     });
-    std::atomic_wait(&done, true);
+    wait_for_value(done, true);
   }
 }

--- a/test/test_nvim_eval.cpp
+++ b/test/test_nvim_eval.cpp
@@ -1,37 +1,48 @@
 #include "nvim.hpp"
 #include <catch2/catch.hpp>
+#include <atomic>
+#include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
 
-TEST_CASE("nvim_eval works", "[nvim_eval]")
+using obj = msgpack::object;
+using obj_handle = msgpack::object_handle;
+using namespace std::chrono_literals;
+
+TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
 {
-  auto nvim = std::make_shared<Nvim>();
-  REQUIRE(nvim->running());
-  SECTION("nvim_eval works for evaluating math")
+  Nvim nvim;
+  REQUIRE(nvim.running());
+  SECTION("Evaluating math")
   {
-    const auto math = nvim->eval("1 + 2").get().as<std::int32_t>();
-    REQUIRE(math == 3);
+    std::atomic<bool> done = false;
+    nvim.eval_cb("1 + 2", [&](obj res, obj err) {
+      REQUIRE(err.is_nil());
+      REQUIRE(res.type == msgpack::type::POSITIVE_INTEGER);
+      REQUIRE(res.as<int>() == 3);
+      done = true;
+    });
+    std::atomic_wait(&done, true);
   }
-  SECTION("nvim_eval can evaluate variables")
+  SECTION("Can evaluate variables")
   {
-    // Everyone can have a different config path,
-    // so we just check that it's not empty
-    const auto config = nvim->eval("stdpath('config')").get().as<std::string>();
-    REQUIRE(!config.empty());
+    std::atomic<bool> done = false;
+    nvim.eval_cb("stdpath('config')", [&](obj res, obj err) {
+      REQUIRE(err.is_nil());
+      REQUIRE(res.type == msgpack::type::STR);
+      done = true;
+    });
+    std::atomic_wait(&done, true);
   }
-  SECTION("nvim_eval returns errors if things don't work out")
+  SECTION("Will send errors in the 'err' parameter")
   {
-    bool exception_occurred = false;
-    try
-    {
-      // When we get an error the output reader gives us an array.
-      // We should run into a type error when we try to convert it.
-      const auto error = nvim->eval("stdpath('')").get().as<std::string>();
-    }
-    catch (const std::exception& e)
-    {
-      exception_occurred = true;
-    }
-    REQUIRE(exception_occurred);
+    std::atomic<bool> done = false;
+    nvim.eval_cb("stdpath", [&](obj res, obj err) {
+      REQUIRE(res.is_nil());
+      REQUIRE(!err.is_nil());
+      done = true;
+    });
+    std::atomic_wait(&done, true);
   }
 }

--- a/test/test_nvim_set_var.cpp
+++ b/test/test_nvim_set_var.cpp
@@ -1,5 +1,7 @@
 #include "nvim.hpp"
+#include "utils.hpp"
 #include <catch2/catch.hpp>
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <memory>
@@ -28,7 +30,7 @@ TEST_CASE("nvim_set_var sets variables properly", "[nvim_set_var]")
       REQUIRE(res.as<int>() == 253);
       done = true;
     });
-    std::atomic_wait(&done, true);
+    wait_for_value(done, true);
   }
   SECTION("nvim_set_var works for strings")
   {
@@ -40,6 +42,6 @@ TEST_CASE("nvim_set_var sets variables properly", "[nvim_set_var]")
       REQUIRE(res.as<std::string>() == "doesthiswork");
       done = true;
     });
-    std::atomic_wait(&done, true);
+    wait_for_value(done, true);
   }
 }

--- a/test/test_nvim_set_var.cpp
+++ b/test/test_nvim_set_var.cpp
@@ -1,12 +1,16 @@
 #include "nvim.hpp"
 #include <catch2/catch.hpp>
 #include <chrono>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <thread>
 
 TEST_CASE("nvim_set_var sets variables properly", "[nvim_set_var]")
 {
+  using std::this_thread::sleep_for;
+  using namespace std::chrono_literals;
+  using obj = msgpack::object;
   // One thing to note: nvim_set_var only works for setting strings and ints
   // (as is said in the header file). However it's just a template method
   // so adding more types is as easy as adding more declarations in the cpp file.
@@ -14,34 +18,28 @@ TEST_CASE("nvim_set_var sets variables properly", "[nvim_set_var]")
   REQUIRE(nvim->running());
   SECTION("nvim_set_var works for ints")
   {
-    bool success = false;
+    std::atomic<bool> done = false;
     nvim->set_var("uniquevariable", 253);
     // Neovim sets a global (g:) variable with the name we gave,
     // so we can get the result from an nvim_eval command.
-    try
-    {
-      const auto result = nvim->eval("g:uniquevariable").get().as<int>();
-      if (result == 253)
-      {
-        success = true;
-      }
-    }
-    catch(const std::exception& e) {}
-    REQUIRE(success);
+    nvim->eval_cb("g:uniquevariable", [&](obj res, obj err) {
+      REQUIRE(err.is_nil());
+      REQUIRE(res.type == msgpack::type::POSITIVE_INTEGER);
+      REQUIRE(res.as<int>() == 253);
+      done = true;
+    });
+    std::atomic_wait(&done, true);
   }
   SECTION("nvim_set_var works for strings")
   {
-    bool success = false;
+    std::atomic<bool> done = false;
     nvim->set_var("uniquevariabletwo", std::string("doesthiswork"));
-    try
-    {
-      const auto result = nvim->eval("g:uniquevariabletwo").get().as<std::string>();
-      if (result == "doesthiswork")
-      {
-        success = true;
-      }
-    }
-    catch (const std::exception& e) {}
-    REQUIRE(success);
+    nvim->eval_cb("g:uniquevariabletwo", [&](obj res, obj err) {
+      REQUIRE(err.is_nil());
+      REQUIRE(res.type == msgpack::type::STR);
+      REQUIRE(res.as<std::string>() == "doesthiswork");
+      done = true;
+    });
+    std::atomic_wait(&done, true);
   }
 }


### PR DESCRIPTION
Fixes #40, #41, #23 
In the current message unpacking strategy, if the data to be unpacked is in a bad format, it throws an exception of 'msgpack::v1::insufficient_bytes' and then terminates.
The desired solution would be able to handle this bad data and smoothly continue on.