### PR TITLE
Windows: Don't send Ctrl, Alt modifiers in a Ctrl+Alt+(Key) sequence

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -924,6 +924,11 @@ void EditorArea::keyPressEvent(QKeyEvent* event)
   bool ctrl = modifiers & Qt::ControlModifier;
   bool shift = modifiers & Qt::ShiftModifier;
   bool alt = modifiers & Qt::AltModifier;
+#ifdef Q_OS_WIN
+  // Windows: Ctrl+Alt (AltGr) is used for alternate characters
+  // don't send modifiers with text
+  if (ctrl && alt) { ctrl = false; alt = false; }
+#endif
   bool is_special = false;
   const QString& text = event->text();
   std::string key = event_to_string(event, &is_special);


### PR DESCRIPTION
Fixes #54 
I don't know if this applies to non-Windows systems, but when using the Ctrl+Alt modifiers for accessing foreign language letters, it sends these modifiers and doesn't achieve the intended behaviour.

Ex. Italian Keyboard on Windows 10:
Steps:
1. Go into insert mode
2. Press Ctrl+Alt+è

Expected Behaviour:
- Enters `[`

Actual:
- Goes into normal mode (Sends a `<M-[>` instead of `[`)
