### PR TITLE
Use native titlebar on macos

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -100,7 +100,11 @@ Window::Window(QWidget* parent, std::shared_ptr<Nvim> nv, int width, int height)
   setMouseTracking(true);
   QObject::connect(this, &Window::resize_done, &editor_area, &decltype(editor_area)::resized);
   prev_state = windowState();
+
+#ifndef Q_OS_MAC
   setWindowFlags(Qt::FramelessWindowHint);
+#endif
+
   const auto font_dims = editor_area.font_dimensions();
   resize(width * std::get<0>(font_dims), height * std::get<1>(font_dims));
   emit resize_done(size());
@@ -114,6 +118,10 @@ Window::Window(QWidget* parent, std::shared_ptr<Nvim> nv, int width, int height)
   QObject::connect(this, &Window::default_colors_changed, [this] { update_titlebar_colors(); });
   QObject::connect(this, &Window::default_colors_changed, &editor_area, &EditorArea::default_colors_changed);
   QObject::connect(this, &Window::win_state_changed, title_bar.get(), &TitleBar::win_state_changed);
+#ifdef Q_OS_MAC
+  title_bar->hide();
+#endif
+
 #ifdef Q_OS_WIN
   windows_setup_frameless((HWND) winId());
 #endif


### PR DESCRIPTION
Hi Guys,

Firstly thanks for creating this. Saw it on hacker news the other day and I have been looking for something like this for a while.  I'm a macos user and I think it would be nice if nvui falls back to use the native macos titlebar. Not sure if this is the best way to do it but its a start. 

Here is a screenshot

![Screen Shot 2021-09-08 at 11 48 21 am](https://user-images.githubusercontent.com/31781/132432983-78897fc4-c7d9-4335-b17c-e8350f6aed07.png)

It might be nice to inject a noop titlebar in to window rather than having ```#ifndef``` every where. I have an idea for this if you would like a better solution. Let me know.