### PR TITLE
Refactor code to remove msgpack::object parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ file(GLOB SOURCES
   src/font.hpp
   src/grid.cpp
   src/grid.hpp
+  src/object.hpp
+  src/object.cpp
   src/decide_renderer.hpp
 )
 if (WIN32)
@@ -134,6 +136,8 @@ file(GLOB TEST_SOURCES
   src/font.hpp
   src/grid.cpp
   src/grid.hpp
+  src/object.hpp
+  src/object.cpp
   src/decide_renderer.hpp
 )
 if (WIN32)

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -68,7 +68,7 @@ void CmdLine::cmdline_show(std::span<const Object> objs)
   //auto* level = arr->at(5).u64();
   if (!c_pos || !firstc) return;
   cursor_pos = static_cast<int>(*c_pos);
-  if (!firstc->isEmpty()) first_char = std::move(*firstc);
+  if (!firstc->empty()) first_char = QString::fromStdString(*firstc);
   else first_char.reset();
   // int indent = arr.ptr[4].as<int>();
   // int level = arr.ptr[5].as<int>();
@@ -248,7 +248,7 @@ void CmdLine::add_line(const ObjectArray& new_line)
     auto& arr = line_obj.get<ObjectArray>();
     assert(arr.size() == 2);
     int hl_id = arr.at(0).try_convert<int>().value_or(0);
-    const QString& text = arr.at(1).get<QString>();
+    const QString& text = QString::fromStdString(arr.at(1).get<std::string>());
     line.emplace_back(text, hl_id);
   }
   lines.push_back(std::move(line));

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -50,30 +50,26 @@ void CmdLine::update_metrics()
   std::tie(big_font_width, big_font_height) = get_font_dimensions_for(big_font);
 }
 
-void CmdLine::cmdline_show(NvimObj obj, msg_size size)
+void CmdLine::cmdline_show(std::span<Object> objs)
 {
-  assert(obj);
   // Clear the previous text
   lines.clear();
-  if (size < 1) return;
-  const msgpack::object& o = obj[size - 1];
-  assert(o.type == msgpack::type::ARRAY);
-  const msgpack::object_array& arr = o.via.array;
-  assert(arr.size == 6);
-  assert(arr.ptr[0].type == msgpack::type::ARRAY);
-  assert(arr.ptr[1].type == msgpack::type::POSITIVE_INTEGER);
-  assert(arr.ptr[2].type == msgpack::type::STR);
-  assert(arr.ptr[3].type == msgpack::type::STR);
-  assert(arr.ptr[4].type == msgpack::type::POSITIVE_INTEGER);
-  assert(arr.ptr[5].type == msgpack::type::POSITIVE_INTEGER);
-  const auto& content = arr.ptr[0].via.array;
-  add_line(content, lines);
-  const int c_pos = arr.ptr[1].as<int>();
-  cursor_pos = c_pos;
-  QString firstc = arr.ptr[2].as<QString>();
-  if (!firstc.isEmpty()) first_char = std::move(firstc);
+  if (objs.empty()) return;
+  auto& obj = objs.back();
+  auto* arr = obj.array();
+  assert(arr && arr->size() >= 6);
+  if (!arr->at(0).has<ObjectArray>()) return;
+  ObjectArray& content = *arr->at(0).array();
+  add_line(content);
+  auto* c_pos = arr->at(1).u64();
+  auto* firstc = arr->at(2).string();
+  //auto* prompt = arr->at(3).string();
+  //auto* indent = arr->at(4).u64();
+  //auto* level = arr->at(5).u64();
+  if (!c_pos || !firstc) return;
+  cursor_pos = static_cast<int>(*c_pos);
+  if (!firstc->isEmpty()) first_char = std::move(*firstc);
   else first_char.reset();
-  QString prompt = arr.ptr[3].as<QString>();
   // int indent = arr.ptr[4].as<int>();
   // int level = arr.ptr[5].as<int>();
   int new_height = padded(fitting_height());
@@ -82,40 +78,38 @@ void CmdLine::cmdline_show(NvimObj obj, msg_size size)
   setVisible(true);
 }
 
-void CmdLine::cmdline_hide(NvimObj obj, msg_size size)
+void CmdLine::cmdline_hide(std::span<Object> objs)
 {
-  Q_UNUSED(obj);
-  Q_UNUSED(size);
+  Q_UNUSED(objs);
   setVisible(false);
 }
 
-void CmdLine::cmdline_cursor_pos(NvimObj obj, msg_size size)
+void CmdLine::cmdline_cursor_pos(std::span<Object> objs)
 {
-  Q_UNUSED(size);
-  assert(obj->type == msgpack::type::ARRAY);
-  const auto& arr = obj->via.array;
-  assert(arr.size == 2);
-  assert(arr.ptr[0].type == msgpack::type::POSITIVE_INTEGER);
-  assert(arr.ptr[1].type == msgpack::type::POSITIVE_INTEGER);
-  const int pos = arr.ptr[0].as<int>();
-  // const int level = arr.ptr[1].as<int>();
-  cursor_pos = pos;
+  for(auto& obj : objs)
+  {
+    auto* arr = obj.array();
+    assert(arr && arr->size() >= 2);
+    assert(arr->at(0).u64() && arr->at(1).u64());
+    cursor_pos = arr->at(0);
+    // const auto level = arr->at(1).get<u64>();
+  }
   update();
 }
 
-void CmdLine::cmdline_special_char(NvimObj, msg_size)
+void CmdLine::cmdline_special_char(std::span<Object>)
 {
 }
 
-void CmdLine::cmdline_block_show(NvimObj, msg_size)
+void CmdLine::cmdline_block_show(std::span<Object>)
 {
 }
 
-void CmdLine::cmdline_block_append(NvimObj, msg_size)
+void CmdLine::cmdline_block_append(std::span<Object>)
 {
 }
 
-void CmdLine::cmdline_block_hide(NvimObj, msg_size)
+void CmdLine::cmdline_block_hide(std::span<Object>)
 {
 }
 
@@ -149,6 +143,7 @@ void CmdLine::paintEvent(QPaintEvent* event)
     pt.x += p.fontMetrics().horizontalAdvance(first_char.value());
   }
   p.setFont(font);
+  const QFontMetrics& font_metrics = p.fontMetrics();
   int cur_char = 0;
   bool cursor_drawn = false;
   QRect inner = inner_rect();
@@ -159,7 +154,7 @@ void CmdLine::paintEvent(QPaintEvent* event)
     {
       for(const QChar& c : seq.first)
       {
-        int text_width = p.fontMetrics().horizontalAdvance(c);
+        int text_width = font_metrics.horizontalAdvance(c);
         if (pt.x + text_width > inner.width())
         {
           pt.x = base_x;
@@ -245,24 +240,19 @@ void CmdLine::draw_text_and_bg(
   painter.drawText(text_start, text);
 }
 
-void CmdLine::add_line(
-  const msgpack::object_array& new_line,
-  std::vector<line>& line_arr
-)
+void CmdLine::add_line(ObjectArray& new_line)
 {
   line line;
-  for(msg_size i = 0; i < new_line.size; ++i)
+  for(auto& line_obj : new_line)
   {
-    assert(new_line.ptr[i].type == msgpack::type::ARRAY);
-    const auto& arr = new_line.ptr[i].via.array;
-    assert(arr.size == 2);
-    assert(arr.ptr[0].type == msgpack::type::POSITIVE_INTEGER);
-    assert(arr.ptr[1].type == msgpack::type::STR);
-    int hl_id = arr.ptr[0].as<int>();
-    QString text = arr.ptr[1].as<QString>();
+    assert(line_obj.has<ObjectArray>());
+    auto& arr = line_obj.get<ObjectArray>();
+    assert(arr.size() == 2);
+    int hl_id = arr.at(0).get_as<int>().value_or(0);
+    QString& text = arr.at(1).get<QString>();
     line.push_back({std::move(text), hl_id});
   }
-  line_arr.push_back(std::move(line));
+  lines.push_back(std::move(line));
 }
 
 

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -50,7 +50,7 @@ void CmdLine::update_metrics()
   std::tie(big_font_width, big_font_height) = get_font_dimensions_for(big_font);
 }
 
-void CmdLine::cmdline_show(std::span<Object> objs)
+void CmdLine::cmdline_show(std::span<const Object> objs)
 {
   // Clear the previous text
   lines.clear();
@@ -59,7 +59,7 @@ void CmdLine::cmdline_show(std::span<Object> objs)
   auto* arr = obj.array();
   assert(arr && arr->size() >= 6);
   if (!arr->at(0).has<ObjectArray>()) return;
-  ObjectArray& content = *arr->at(0).array();
+  const ObjectArray& content = *arr->at(0).array();
   add_line(content);
   auto* c_pos = arr->at(1).u64();
   auto* firstc = arr->at(2).string();
@@ -78,13 +78,13 @@ void CmdLine::cmdline_show(std::span<Object> objs)
   setVisible(true);
 }
 
-void CmdLine::cmdline_hide(std::span<Object> objs)
+void CmdLine::cmdline_hide(std::span<const Object> objs)
 {
   Q_UNUSED(objs);
   setVisible(false);
 }
 
-void CmdLine::cmdline_cursor_pos(std::span<Object> objs)
+void CmdLine::cmdline_cursor_pos(std::span<const Object> objs)
 {
   for(auto& obj : objs)
   {
@@ -97,19 +97,19 @@ void CmdLine::cmdline_cursor_pos(std::span<Object> objs)
   update();
 }
 
-void CmdLine::cmdline_special_char(std::span<Object>)
+void CmdLine::cmdline_special_char(std::span<const Object>)
 {
 }
 
-void CmdLine::cmdline_block_show(std::span<Object>)
+void CmdLine::cmdline_block_show(std::span<const Object>)
 {
 }
 
-void CmdLine::cmdline_block_append(std::span<Object>)
+void CmdLine::cmdline_block_append(std::span<const Object>)
 {
 }
 
-void CmdLine::cmdline_block_hide(std::span<Object>)
+void CmdLine::cmdline_block_hide(std::span<const Object>)
 {
 }
 
@@ -242,7 +242,7 @@ void CmdLine::draw_text_and_bg(
   painter.drawText(text_start, text);
 }
 
-void CmdLine::add_line(ObjectArray& new_line)
+void CmdLine::add_line(const ObjectArray& new_line)
 {
   line line;
   for(auto& line_obj : new_line)
@@ -251,8 +251,8 @@ void CmdLine::add_line(ObjectArray& new_line)
     auto& arr = line_obj.get<ObjectArray>();
     assert(arr.size() == 2);
     int hl_id = arr.at(0).get_as<int>().value_or(0);
-    QString& text = arr.at(1).get<QString>();
-    line.push_back({std::move(text), hl_id});
+    const QString& text = arr.at(1).get<QString>();
+    line.emplace_back(text, hl_id);
   }
   lines.push_back(std::move(line));
 }

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -91,7 +91,7 @@ void CmdLine::cmdline_cursor_pos(std::span<const Object> objs)
     auto* arr = obj.array();
     assert(arr && arr->size() >= 2);
     assert(arr->at(0).u64() && arr->at(1).u64());
-    cursor_pos = arr->at(0);
+    cursor_pos = (int) arr->at(0);
     // const auto level = arr->at(1).get<u64>();
   }
   update();
@@ -250,7 +250,7 @@ void CmdLine::add_line(const ObjectArray& new_line)
     assert(line_obj.has<ObjectArray>());
     auto& arr = line_obj.get<ObjectArray>();
     assert(arr.size() == 2);
-    int hl_id = arr.at(0).get_as<int>().value_or(0);
+    int hl_id = arr.at(0).try_convert<int>().value_or(0);
     const QString& text = arr.at(1).get<QString>();
     line.emplace_back(text, hl_id);
   }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -14,13 +14,13 @@ class CmdLine : public QWidget
 public:
   CmdLine(const HLState* hl_state, Cursor* cursor, QWidget* parent = nullptr);
   /// Neovim event handlers
-  void cmdline_show(std::span<Object> objs);
-  void cmdline_hide(std::span<Object> objs);
-  void cmdline_cursor_pos(std::span<Object> objs);
-  void cmdline_special_char(std::span<Object> objs);
-  void cmdline_block_show(std::span<Object> objs);
-  void cmdline_block_append(std::span<Object> objs);
-  void cmdline_block_hide(std::span<Object> objs);
+  void cmdline_show(std::span<const Object> objs);
+  void cmdline_hide(std::span<const Object> objs);
+  void cmdline_cursor_pos(std::span<const Object> objs);
+  void cmdline_special_char(std::span<const Object> objs);
+  void cmdline_block_show(std::span<const Object> objs);
+  void cmdline_block_append(std::span<const Object> objs);
+  void cmdline_block_hide(std::span<const Object> objs);
   /**
    * Returns where the popup menu should be positioned.
    */
@@ -185,7 +185,7 @@ private:
   std::optional<float> centered_x;
   std::optional<float> centered_y;
   // Parse and add new lines from new_line to line_arr.
-  void add_line(ObjectArray& new_line);
+  void add_line(const ObjectArray& new_line);
   const HLState* state = nullptr;
   // Owned by EditorArea, but so is the cmdline
   // so there should be no problems

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -12,17 +12,15 @@
 class CmdLine : public QWidget
 {
 public:
-  using NvimObj = const msgpack::object*;
-  using msg_size = std::uint32_t;
   CmdLine(const HLState* hl_state, Cursor* cursor, QWidget* parent = nullptr);
   /// Neovim event handlers
-  void cmdline_show(NvimObj obj, msg_size size);
-  void cmdline_hide(NvimObj obj, msg_size size);
-  void cmdline_cursor_pos(NvimObj obj, msg_size size);
-  void cmdline_special_char(NvimObj obj, msg_size size);
-  void cmdline_block_show(NvimObj obj, msg_size size);
-  void cmdline_block_append(NvimObj obj, msg_size size);
-  void cmdline_block_hide(NvimObj obj, msg_size size);
+  void cmdline_show(std::span<Object> objs);
+  void cmdline_hide(std::span<Object> objs);
+  void cmdline_cursor_pos(std::span<Object> objs);
+  void cmdline_special_char(std::span<Object> objs);
+  void cmdline_block_show(std::span<Object> objs);
+  void cmdline_block_append(std::span<Object> objs);
+  void cmdline_block_hide(std::span<Object> objs);
   /**
    * Returns where the popup menu should be positioned.
    */
@@ -187,10 +185,7 @@ private:
   std::optional<float> centered_x;
   std::optional<float> centered_y;
   // Parse and add new lines from new_line to line_arr.
-  void add_line(
-    const msgpack::object_array& new_line,
-    std::vector<line>& line_arr
-  );
+  void add_line(ObjectArray& new_line);
   const HLState* state = nullptr;
   // Owned by EditorArea, but so is the cmdline
   // so there should be no problems

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -61,7 +61,7 @@ Cursor::Cursor(EditorArea* ea)
   });
 }
 
-void Cursor::mode_change(std::span<Object> objs)
+void Cursor::mode_change(std::span<const Object> objs)
 {
   for(const auto& o : objs)
   {
@@ -76,7 +76,7 @@ void Cursor::mode_change(std::span<Object> objs)
   reset_timers();
 }
 
-void Cursor::mode_info_set(std::span<Object> objs)
+void Cursor::mode_info_set(std::span<const Object> objs)
 {
   mode_info.clear();
   for(const auto& o : objs)

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -61,46 +61,41 @@ Cursor::Cursor(EditorArea* ea)
   });
 }
 
-void Cursor::mode_change(const msgpack::object* obj, std::uint32_t size)
+void Cursor::mode_change(std::span<Object> objs)
 {
-  Q_UNUSED(size);
-  assert(obj->type == msgpack::type::ARRAY);
-  const auto& arr = obj->via.array;
-  assert(arr.size == 2);
-  const std::string mode_name = arr.ptr[0].as<std::string>();
-  // Save the old position
-  if (cur_pos.has_value()) old_mode_idx = cur_mode_idx;
-  cur_mode_idx = arr.ptr[1].as<std::size_t>();
-  if (cur_mode_idx >= mode_info.size())
+  for(const auto& o : objs)
   {
-    return;
+    auto* arr = o.array();
+    if (!(arr && arr->size() >= 2)) continue;
+    const auto mode_name = arr->at(0).string()->toStdString();
+    if (cur_pos) old_mode_idx = cur_mode_idx;
+    if (!arr->at(1).u64()) continue;
+    cur_mode_idx = *arr->at(1).u64();
+    cur_mode = mode_info.at(cur_mode_idx);
   }
-  cur_mode = mode_info.at(cur_mode_idx);
   reset_timers();
 }
 
-void Cursor::mode_info_set(const msgpack::object* obj, std::uint32_t size)
+void Cursor::mode_info_set(std::span<Object> objs)
 {
   mode_info.clear();
-  for(std::uint32_t i = 0; i < size; ++i)
+  for(const auto& o : objs)
   {
-    const msgpack::object& o = obj[i];
-    assert(o.type == msgpack::type::ARRAY);
-    const auto& arr = o.via.array;
-    assert(arr.size == 2);
-    // const bool cursor_style_enabled = arr.ptr[0].as<bool>();
-    const auto& modes_arr = arr.ptr[1].via.array;
-    for(std::uint32_t j = 0; j < modes_arr.size; ++j)
+    auto* arr = o.array();
+    if (!(arr && arr->size() >= 2)) continue;
+    const auto modes_arr = arr->at(1).array();
+    if (!modes_arr) continue;
+    for(const auto& m : *modes_arr)
     {
-      const msgpack::object_map& map = modes_arr.ptr[j].via.map;
+      if (!m.has<ObjectMap>()) continue;
+      const auto& map = *m.map();
       ModeInfo mode {};
-      for(std::uint32_t k = 0; k < map.size; ++k)
+      for(const auto& [key, val] : map)
       {
-        const msgpack::object_kv kv = map.ptr[k];
-        const std::string key = kv.key.as<std::string>();
         if (key == "cursor_shape")
         {
-          const std::string shape = kv.val.as<std::string>();
+          if (!val.string()) continue;
+          const QString shape = *val.string();
           if (shape == "horizontal")
           {
             mode.cursor_shape = CursorShape::Horizontal;
@@ -116,35 +111,35 @@ void Cursor::mode_info_set(const msgpack::object* obj, std::uint32_t size)
         }
         else if (key == "cell_percentage")
         {
-          mode.cell_percentage = kv.val.as<int>();
+          mode.cell_percentage = val;
         }
         else if (key == "attr_id")
         {
-          mode.attr_id = kv.val.as<int>();
+          mode.attr_id = val;
         }
         else if (key == "attr_id_lm")
         {
-          mode.attr_id_lm = kv.val.as<int>();
+          mode.attr_id_lm = val;
         }
         else if (key == "short_name")
         {
-          mode.short_name = kv.val.as<std::string>();
+          mode.short_name = val.string()->toStdString();
         }
         else if (key == "name")
         {
-          mode.name = kv.val.as<std::string>();
+          mode.name = val.string()->toStdString();
         }
         else if (key == "blinkwait")
         {
-          mode.blinkwait = kv.val.as<int>();
+          mode.blinkwait = val;
         }
         else if (key == "blinkon")
         {
-          mode.blinkon = kv.val.as<int>();
+          mode.blinkon = val;
         }
         else if (key == "blinkoff")
         {
-          mode.blinkoff = kv.val.as<int>();
+          mode.blinkoff = val;
         }
       }
       mode_info.push_back(std::move(mode));

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -111,15 +111,15 @@ void Cursor::mode_info_set(std::span<const Object> objs)
         }
         else if (key == "cell_percentage")
         {
-          mode.cell_percentage = val;
+          mode.cell_percentage = (int) val;
         }
         else if (key == "attr_id")
         {
-          mode.attr_id = val;
+          mode.attr_id = (int) val;
         }
         else if (key == "attr_id_lm")
         {
-          mode.attr_id_lm = val;
+          mode.attr_id_lm = (int) val;
         }
         else if (key == "short_name")
         {
@@ -131,15 +131,15 @@ void Cursor::mode_info_set(std::span<const Object> objs)
         }
         else if (key == "blinkwait")
         {
-          mode.blinkwait = val;
+          mode.blinkwait = (int) val;
         }
         else if (key == "blinkon")
         {
-          mode.blinkon = val;
+          mode.blinkon = (int) val;
         }
         else if (key == "blinkoff")
         {
-          mode.blinkoff = val;
+          mode.blinkoff = (int) val;
         }
       }
       mode_info.push_back(std::move(mode));

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -67,7 +67,7 @@ void Cursor::mode_change(std::span<const Object> objs)
   {
     auto* arr = o.array();
     if (!(arr && arr->size() >= 2)) continue;
-    const auto mode_name = arr->at(0).string()->toStdString();
+    const auto mode_name = arr->at(0).get<std::string>();
     if (cur_pos) old_mode_idx = cur_mode_idx;
     if (!arr->at(1).u64()) continue;
     cur_mode_idx = *arr->at(1).u64();
@@ -95,7 +95,7 @@ void Cursor::mode_info_set(std::span<const Object> objs)
         if (key == "cursor_shape")
         {
           if (!val.string()) continue;
-          const QString shape = *val.string();
+          const auto shape = *val.string();
           if (shape == "horizontal")
           {
             mode.cursor_shape = CursorShape::Horizontal;
@@ -123,11 +123,11 @@ void Cursor::mode_info_set(std::span<const Object> objs)
         }
         else if (key == "short_name")
         {
-          mode.short_name = val.string()->toStdString();
+          mode.short_name = *val.string();
         }
         else if (key == "name")
         {
-          mode.name = val.string()->toStdString();
+          mode.name = *val.string();
         }
         else if (key == "blinkwait")
         {

--- a/src/cursor.hpp
+++ b/src/cursor.hpp
@@ -73,11 +73,11 @@ public:
   /**
    * Handles a 'mode_info_set' Neovim redraw event.
    */
-  void mode_info_set(std::span<Object> objs);
+  void mode_info_set(std::span<const Object> objs);
   /**
    * Handles a 'mode_change' Neovim redraw event.
    */
-  void mode_change(std::span<Object> objs);
+  void mode_change(std::span<const Object> objs);
   /**
    * Set the current position to pos, and refresh the cursor.
    */

--- a/src/cursor.hpp
+++ b/src/cursor.hpp
@@ -5,9 +5,11 @@
 #include <QRect>
 #include <QTimer>
 #include <cstdint>
+#include <span>
 #include <msgpack.hpp>
 #include "hlstate.hpp"
 #include "grid.hpp"
+#include "object.hpp"
 
 enum class CursorShape : std::uint8_t
 {
@@ -71,11 +73,11 @@ public:
   /**
    * Handles a 'mode_info_set' Neovim redraw event.
    */
-  void mode_info_set(const msgpack::object* obj, std::uint32_t size);
+  void mode_info_set(std::span<Object> objs);
   /**
    * Handles a 'mode_change' Neovim redraw event.
    */
-  void mode_change(const msgpack::object* obj, std::uint32_t size);
+  void mode_change(std::span<Object> objs);
   /**
    * Set the current position to pos, and refresh the cursor.
    */

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -371,7 +371,6 @@ void EditorArea::win_float_pos(std::span<NeovimObj> objs)
       float pum_ty = std::ceil(pum_tr.y() / font_height);
       anchor_pos = QPoint(pum_rx, pum_ty);
     }
-    shift_z(grid->z_index);
     bool were_animations_enabled = animations_enabled();
     set_animations_enabled(false);
     grid->set_pos(anchor_pos);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -151,6 +151,7 @@ void EditorArea::grid_resize(std::span<NeovimObj> objs)
       create_grid(0, 0, width, height, grid_num);
       grid = find_grid(grid_num);
       // Created grid appears above all others
+      move_to_top(grid);
     }
     if (grid)
     {
@@ -314,6 +315,7 @@ void EditorArea::win_pos(std::span<NeovimObj> objs)
     grid->hidden = false;
     grid->win_pos(sc, sr);
     grid->set_size(width, height);
+    move_to_top(grid);
     grid->winid = get_win(win);
   }
   send_redraw();
@@ -374,6 +376,7 @@ void EditorArea::win_float_pos(std::span<NeovimObj> objs)
     bool were_animations_enabled = animations_enabled();
     set_animations_enabled(false);
     grid->winid = get_win(win);
+    move_to_top(grid);
     grid->float_pos(anchor_pos.x(), anchor_pos.y());
     set_animations_enabled(were_animations_enabled);
   }
@@ -430,6 +433,7 @@ void EditorArea::msg_set_pos(std::span<NeovimObj> objs)
     if (GridBase* grid = find_grid(grid_num))
     {
       grid->set_pos(grid->x, row);
+      move_to_top(grid);
     }
   }
   send_redraw();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -152,7 +152,7 @@ void EditorArea::grid_line(std::span<NeovimObj> objs)
       assert(cell_arr.size() >= 1 && cell_arr.size() <= 3);
       // [text, (hl_id, repeat)]
       int repeat = 1;
-      assert(cell_arr.at(0).has<QString>());
+      assert(cell_arr.at(0).is_string());
       grid_char text = GridChar::grid_char_from_str(cell_arr[0].get<std::string>());
       // If the previous char was a double-width char,
       // the current char is an empty string.

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -137,7 +137,7 @@ void EditorArea::grid_resize(std::span<NeovimObj> objs)
   // Should only run once
   for(const auto& obj : objs)
   {
-    auto vars = obj.decompose<u64, u64, u64>();
+    auto vars = obj.try_decompose<u64, u64, u64>();
     if (!vars) continue;
     auto [grid_num, width, height] = *vars;
     assert(grid_num != 0);
@@ -161,7 +161,7 @@ void EditorArea::grid_resize(std::span<NeovimObj> objs)
 
 void EditorArea::grid_line(std::span<NeovimObj> objs)
 {
-  std::uint16_t hl_id = 0;
+  int hl_id = 0;
   //std::cout << "Received grid line.\nNum params: " << size << '\n';
   for(auto& grid_cmd : objs)
   {
@@ -172,8 +172,8 @@ void EditorArea::grid_line(std::span<NeovimObj> objs)
     if (!grid_ptr) continue;
     if (!grid_ptr) return;
     GridBase& g = *grid_ptr;
-    int start_row = arr->at(1);
-    int start_col = arr->at(2);
+    int start_row = (int) arr->at(1);
+    int start_col = (int) arr->at(2);
     int col = start_col;
     auto cells = arr->at(3).array();
     assert(cells);
@@ -203,11 +203,11 @@ void EditorArea::grid_line(std::span<NeovimObj> objs)
       switch(cell_arr.size())
       {
         case 2:
-          hl_id = cell_arr.at(1);
+          hl_id = (int) cell_arr.at(1);
           break;
         case 3:
-          hl_id = cell_arr.at(1);
-          repeat = cell_arr.at(2);
+          hl_id = (int) cell_arr.at(1);
+          repeat = (int) cell_arr.at(2);
           break;
       }
       //std::cout << "Code point: " << c << "\n";
@@ -227,7 +227,7 @@ void EditorArea::grid_cursor_goto(std::span<NeovimObj> objs)
 {
   if (objs.empty()) return;
   const auto& obj = objs.back();
-  auto vars = obj.decompose<u16, int, int>();
+  auto vars = obj.try_decompose<u16, int, int>();
   if (!vars) return;
   auto [grid_num, row, col] = *vars;
   GridBase* grid = find_grid(grid_num);
@@ -276,7 +276,7 @@ void EditorArea::option_set(std::span<NeovimObj> objs)
     }
     else if (opt == "linespace")
     {
-      auto int_opt = arr->at(1).get_as<int>();
+      auto int_opt = arr->at(1).try_convert<int>();
       assert(int_opt);
       linespace = *int_opt;
       update_font_metrics();
@@ -302,7 +302,7 @@ void EditorArea::win_pos(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto vars = obj.decompose<u64, NeovimExt, u64, u64, u64, u64>();
+    auto vars = obj.try_decompose<u64, NeovimExt, u64, u64, u64, u64>();
     if (!vars) continue;
     const auto& [grid_num, win, sr, sc, width, height] = *vars;
     GridBase* grid = find_grid(grid_num);
@@ -335,7 +335,7 @@ void EditorArea::win_float_pos(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto vars = obj.decompose<u64, NeovimExt, QString, u64, int, int>();
+    auto vars = obj.try_decompose<u64, NeovimExt, QString, u64, int, int>();
     if (!vars) continue;
     auto [grid_num, win, anchor_dir, anchor_grid_num, anchor_row, anchor_col] = *vars;
     QPoint anchor_rel = {anchor_col, anchor_row};
@@ -396,7 +396,7 @@ void EditorArea::win_viewport(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto vars = obj.decompose<u64, NeovimExt, u32, u32, u32, u32>();
+    auto vars = obj.try_decompose<u64, NeovimExt, u32, u32, u32, u32>();
     if (!vars) continue;
     auto [grid_num, ext, topline, botline, curline, curcol] = *vars;
     Viewport vp = {topline, botline, curline, curcol};
@@ -422,7 +422,7 @@ void EditorArea::msg_set_pos(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto vars = obj.decompose<u64, u64>();
+    auto vars = obj.try_decompose<u64, u64>();
     if (!vars) continue;
     auto [grid_num, row] = *vars;
     //auto scrolled = arr.ptr[2].as<bool>();
@@ -761,7 +761,7 @@ void EditorArea::grid_scroll(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto vars = obj.decompose<u16, u16, u16, u16, u16, int>();
+    auto vars = obj.try_decompose<u16, u16, u16, u16, u16, int>();
     if (!vars) continue;
     const auto [grid_num, top, bot, left, right, rows] = *vars;
     // const int cols = arr->at(6);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -135,7 +135,6 @@ void EditorArea::grid_resize(std::span<NeovimObj> objs)
   // Should only run once
   for(const auto& obj : objs)
   {
-    assert(obj.array() && obj.array()->size() >= 3);
     auto vars = obj.decompose<u64, u64, u64>();
     if (!vars) continue;
     auto [grid_num, width, height] = *vars;
@@ -222,9 +221,6 @@ void EditorArea::grid_cursor_goto(std::span<NeovimObj> objs)
 {
   if (objs.empty()) return;
   const auto& obj = objs.back();
-  auto* arr = obj.array();
-  Q_UNUSED(arr);
-  assert(arr && arr->size() >= 3);
   auto vars = obj.decompose<u16, int, int>();
   if (!vars) return;
   auto [grid_num, row, col] = *vars;
@@ -297,9 +293,6 @@ void EditorArea::win_pos(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto* arr = obj.array();
-    Q_UNUSED(arr);
-    assert(arr && arr->size() >= 6);
     auto vars = obj.decompose<u64, NeovimExt, u64, u64, u64, u64>();
     if (!vars) continue;
     auto [grid_num, ext, sr, sc, width, height] = *vars;
@@ -334,8 +327,6 @@ void EditorArea::win_float_pos(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto* arr = obj.array();
-    if (!(arr && arr->size() >= 7)) continue;
     auto vars = obj.decompose<u64, NeovimExt, QString, u64, int, int>();
     if (!vars) continue;
     auto [grid_num, win, anchor_dir, anchor_grid_num, anchor_row, anchor_col] = *vars;
@@ -389,8 +380,6 @@ void EditorArea::win_viewport(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    //auto* arr = obj.array();
-    assert(obj.array());
     auto vars = obj.decompose<u64, NeovimExt, u32, u32, u32, u32>();
     if (!vars) continue;
     auto [grid_num, ext, topline, botline, curline, curcol] = *vars;
@@ -417,9 +406,6 @@ void EditorArea::msg_set_pos(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto* arr = obj.array();
-    Q_UNUSED(arr);
-    assert(arr && arr->size() >= 4);
     auto vars = obj.decompose<u64, u64>();
     if (!vars) continue;
     auto [grid_num, row] = *vars;
@@ -734,9 +720,6 @@ void EditorArea::grid_scroll(std::span<NeovimObj> objs)
 {
   for(const auto& obj : objs)
   {
-    auto* arr = obj.array();
-    Q_UNUSED(arr);
-    assert(arr && arr->size() >= 7);
     auto vars = obj.decompose<u16, u16, u16, u16, u16, int>();
     if (!vars) continue;
     const auto [grid_num, top, bot, left, right, rows] = *vars;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -304,7 +304,7 @@ void EditorArea::win_pos(std::span<NeovimObj> objs)
   {
     auto vars = obj.decompose<u64, NeovimExt, u64, u64, u64, u64>();
     if (!vars) continue;
-    auto [grid_num, win, sr, sc, width, height] = *vars;
+    const auto& [grid_num, win, sr, sc, width, height] = *vars;
     GridBase* grid = find_grid(grid_num);
     if (!grid)
     {
@@ -312,9 +312,9 @@ void EditorArea::win_pos(std::span<NeovimObj> objs)
       continue;
     }
     grid->hidden = false;
+    grid->win_pos(sc, sr);
     grid->set_size(width, height);
     grid->winid = get_win(win);
-    QRect r(0, 0, grid->cols, grid->rows);
   }
   send_redraw();
 }
@@ -375,7 +375,6 @@ void EditorArea::win_float_pos(std::span<NeovimObj> objs)
     set_animations_enabled(false);
     grid->winid = get_win(win);
     grid->float_pos(anchor_pos.x(), anchor_pos.y());
-    grid->z_index = grids.size() - 1;
     set_animations_enabled(were_animations_enabled);
   }
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -693,7 +693,6 @@ void EditorArea::grid_scroll(std::span<NeovimObj> objs)
     // const int cols = arr->at(6);
     GridBase* grid = find_grid(grid_num);
     if (!grid) return;
-    assert(grid);
     if (rows > 0)
     {
       for(int y = top; y < (bot - rows); ++y)

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -295,7 +295,7 @@ void EditorArea::win_pos(std::span<NeovimObj> objs)
   {
     auto vars = obj.decompose<u64, NeovimExt, u64, u64, u64, u64>();
     if (!vars) continue;
-    auto [grid_num, ext, sr, sc, width, height] = *vars;
+    auto [grid_num, win, sr, sc, width, height] = *vars;
     GridBase* grid = find_grid(grid_num);
     if (!grid)
     {
@@ -305,7 +305,7 @@ void EditorArea::win_pos(std::span<NeovimObj> objs)
     grid->hidden = false;
     grid->set_pos(sc, sr);
     grid->set_size(width, height);
-    grid->winid = get_win(ext);
+    grid->winid = get_win(win);
     QRect r(0, 0, grid->cols, grid->rows);
   }
   send_redraw();

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -537,22 +537,19 @@ protected:
   void send_clear(std::uint16_t grid_num, QRect r = {});
   /// Draw a portion of the grid
   void send_draw(std::uint16_t grid_num, QRect r);
-  /// Shift down all grids with a z index greater than idx
-  /// by 1.
-  void shift_z(std::size_t idx)
-  {
-    for(auto& g : grids)
-    {
-      if (g->z_index > idx) --g->z_index;
-    }
-  }
-  /// Sorts grids in order of their z index, from
-  /// lowest to highest.
+  /// Sorts grids in order of their z index.
   void sort_grids_by_z_index()
   {
     std::sort(grids.begin(), grids.end(), [](const auto& g1, const auto& g2) {
-      return g1->z_index < g2->z_index;
+      return g1->winid < g2->winid;
     });
+  }
+  /// Returns an integer identifier for the window.
+  u64 get_win(const NeovimExt& ext)
+  {
+    u64 x = 0;
+    for(const auto& c : ext.data) x += static_cast<std::uint8_t>(c);
+    return x;
   }
 public slots:
   /**

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -92,7 +92,7 @@ class EditorArea : public QWidget
 {
   Q_OBJECT
 public:
-  using NeovimObj = Object;
+  using NeovimObj = const Object;
   using u64 = std::uint64_t;
   using u32 = std::uint32_t;
   using u16 = std::uint16_t;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -572,11 +572,26 @@ protected:
   void send_clear(std::uint16_t grid_num, QRect r = {});
   /// Draw a portion of the grid
   void send_draw(std::uint16_t grid_num, QRect r);
+  void move_to_top(GridBase* grid)
+  {
+    if (grid->z_index == grids.size() - 1) return;
+    shift_z(grid->z_index);
+    grid->z_index = grids.size() - 1;
+  }
+  /// Shift down all grids with a z index greater than idx
+  /// by 1.
+  void shift_z(std::size_t idx)
+  {
+    for(auto& g : grids)
+    {
+      if (g->z_index > idx) --g->z_index;
+    }
+  }
   /// Sorts grids in order of their z index.
   void sort_grids_by_z_index()
   {
     std::sort(grids.begin(), grids.end(), [](const auto& g1, const auto& g2) {
-      return g1->winid < g2->winid;
+      return g1->z_index < g2->z_index;
     });
   }
   /// Returns an integer identifier for the window.

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -23,9 +23,6 @@
 #include "grid.hpp"
 #include "object.hpp"
 
-// For easily changing the type of 'char' in a cell
-using grid_char = QString;
-
 /// UI Capabilities (Extensions)
 struct ExtensionCapabilities
 {
@@ -456,19 +453,6 @@ protected:
    * uses a default font given by default_font_family() in utils.hpp.
    */
   void set_guifont(QString new_font);
-  /**
-   * Adds text to the given grid number at the given row and col number,
-   * overwriting the previous text a the position.
-   */
-  void set_text(
-    GridBase& g,
-    grid_char c,
-    std::uint16_t row,
-    std::uint16_t col,
-    std::uint16_t hl_id,
-    std::uint16_t repeat = 1,
-    bool is_dbl_width = false
-  );
   /**
    * Returns a grid with the matching grid_num
    */

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <queue>
+#include <span>
 #include <msgpack.hpp>
 #include <QFont>
 #include <QObject>
@@ -20,6 +21,7 @@
 #include "cmdline.hpp"
 #include "font.hpp"
 #include "grid.hpp"
+#include "object.hpp"
 
 // For easily changing the type of 'char' in a cell
 using grid_char = QString;
@@ -40,7 +42,8 @@ class EditorArea : public QWidget
 {
   Q_OBJECT
 public:
-  using NeovimObj = const msgpack::object*;
+  using NeovimObj = Object;
+  using u64 = std::uint64_t;
   using u32 = std::uint32_t;
   using u16 = std::uint16_t;
   EditorArea(
@@ -51,19 +54,19 @@ public:
   /**
    * Handles a Neovim "grid_resize" event.
    */
-  void grid_resize(NeovimObj obj, u32 size);
+  void grid_resize(std::span<NeovimObj> objs);
   /**
    * Handles a Neovim "grid_line" event.
    */
-  void grid_line(NeovimObj obj, u32 size);
+  void grid_line(std::span<NeovimObj> objs);
   /**
    * Paints the grid cursor at the given grid, row, and column.
    */
-  void grid_cursor_goto(NeovimObj obj, u32 size);
+  void grid_cursor_goto(std::span<NeovimObj> objs);
   /**
    * Handles a Neovim "option_set" event.
    */
-  void option_set(NeovimObj obj, u32 size);
+  void option_set(std::span<NeovimObj> objs);
   /**
    * Handles a Neovim "flush" event.
    * This paints the internal buffer onto the window.
@@ -72,27 +75,27 @@ public:
   /**
    * Handles a Neovim "win_pos" event.
    */
-  void win_pos(NeovimObj obj, u32 size);
+  void win_pos(std::span<NeovimObj> objs);
   /**
    * Handles a Neovim "win_hide" event.
    */
-  void win_hide(NeovimObj obj, u32 size);
+  void win_hide(std::span<NeovimObj> objs);
   /**
    * Handles a Neovim "win_float_pos" event.
    */
-  void win_float_pos(NeovimObj obj, u32 size);
+  void win_float_pos(std::span<NeovimObj> objs);
   /**
    * Handles a Neovim "win_close" event.
    */
-  void win_close(NeovimObj obj, u32 size);
+  void win_close(std::span<NeovimObj> objs);
   /**
    * Handles a Neovim "win_viewport" event.
    */
-  void win_viewport(NeovimObj obj, u32 size);
+  void win_viewport(std::span<NeovimObj> objs);
   /// Handles a Neovim "grid_destroy" event.
-  void grid_destroy(NeovimObj obj, u32 size);
+  void grid_destroy(std::span<NeovimObj> objs);
   /// Handles a Neovim "msg_set_pos" event.
-  void msg_set_pos(NeovimObj obj, u32 size);
+  void msg_set_pos(std::span<NeovimObj> objs);
   /**
    * Returns the font width and font height.
    */
@@ -105,11 +108,11 @@ public:
   /**
    * Handles a Neovim "grid_clear" event
    */
-  void grid_clear(NeovimObj obj, u32 size);
+  void grid_clear(std::span<NeovimObj> objs);
   /**
    * Handles a Neovim "grid_scroll" event
    */
-  void grid_scroll(NeovimObj obj, u32 size);
+  void grid_scroll(std::span<NeovimObj> objs);
   /**
    * Notify the editor area when resizing is enabled/disabled.
    */
@@ -118,12 +121,12 @@ public:
    * Handles a "mode_info_set" Neovim redraw event.
    * Internally sends the data to neovim_cursor.
    */
-  void mode_info_set(NeovimObj obj, u32 size);
+  void mode_info_set(std::span<NeovimObj> objs);
   /**
    * Handles a "mode_change" Neovim event.
    * Internally sends the data to neovim_cursor.
    */
-  void mode_change(NeovimObj obj, u32 size);
+  void mode_change(std::span<NeovimObj> objs);
   /**
    * Handles a "busy_start" event, passing it to the Neovim cursor
    */
@@ -156,19 +159,19 @@ public:
   inline void set_caret_top(float top) { neovim_cursor.set_caret_extend_top(top); }
   inline void set_caret_bottom(float bot) { neovim_cursor.set_caret_extend_bottom(bot); }
 
-  inline void popupmenu_show(NeovimObj obj, u32 size)
+  inline void popupmenu_show(std::span<NeovimObj> objs)
   {
-    popup_menu.pum_show(obj, size);
+    popup_menu.pum_show(objs);
   }
 
-  inline void popupmenu_hide(NeovimObj obj, u32 size)
+  inline void popupmenu_hide(std::span<NeovimObj> objs)
   {
-    popup_menu.pum_hide(obj, size);
+    popup_menu.pum_hide(objs);
   }
 
-  inline void popupmenu_select(NeovimObj obj, u32 size)
+  inline void popupmenu_select(std::span<NeovimObj> objs)
   {
-    popup_menu.pum_sel(obj, size);
+    popup_menu.pum_sel(objs);
   }
 
   inline void popupmenu_icons_toggle()
@@ -221,21 +224,21 @@ public:
 
   inline void popupmenu_set_icons_right(bool right) { popup_menu.set_icons_on_right(right); }
 
-  inline void cmdline_show(NeovimObj obj, u32 size)
+  inline void cmdline_show(std::span<NeovimObj> objs)
   {
-    cmdline.cmdline_show(obj, size);
+    cmdline.cmdline_show(objs);
     popup_menu.attach_cmdline(cmdline.width());
   }
-  inline void cmdline_hide(NeovimObj obj, u32 size)
+  inline void cmdline_hide(std::span<NeovimObj> objs)
   {
-    cmdline.cmdline_hide(obj, size);
+    cmdline.cmdline_hide(objs);
     popup_menu.detach_cmdline();
   }
-  inline void cmdline_cursor_pos(NeovimObj obj, u32 size) { cmdline.cmdline_cursor_pos(obj, size); }
-  inline void cmdline_special_char(NeovimObj obj, u32 size) { cmdline.cmdline_special_char(obj, size); }
-  inline void cmdline_block_show(NeovimObj obj, u32 size) { cmdline.cmdline_block_show(obj, size); }
-  inline void cmdline_block_append(NeovimObj obj, u32 size) { cmdline.cmdline_block_append(obj, size); }
-  inline void cmdline_block_hide(NeovimObj obj, u32 size) { cmdline.cmdline_block_hide(obj, size); }
+  inline void cmdline_cursor_pos(std::span<NeovimObj> objs) { cmdline.cmdline_cursor_pos(objs); }
+  inline void cmdline_special_char(std::span<NeovimObj> objs) { cmdline.cmdline_special_char(objs); }
+  inline void cmdline_block_show(std::span<NeovimObj> objs) { cmdline.cmdline_block_show(objs); }
+  inline void cmdline_block_append(std::span<NeovimObj> objs) { cmdline.cmdline_block_append(objs); }
+  inline void cmdline_block_hide(std::span<NeovimObj> objs) { cmdline.cmdline_block_hide(objs); }
   inline void reposition_cmdline()
   {
     QPointF rel_pos = cmdline.relative_pos();

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -6,6 +6,11 @@
 scalers::time_scaler GridBase::scroll_scaler = scalers::oneminusexpo2negative10;
 scalers::time_scaler GridBase::move_scaler = scalers::oneminusexpo2negative10;
 
+grid_char GridChar::grid_char_from_str(const std::string& s)
+{
+  return QString::fromStdString(s);
+}
+
 void QPaintGrid::update_pixmap_size()
 {
   auto&& [font_width, font_height] = editor_area->font_dimensions();

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -292,6 +292,7 @@ public:
   u16 cols;
   u16 rows;
   u16 id;
+  std::size_t z_index = 0;
   std::int64_t winid = 0;
   std::vector<GridChar> area; // Size = rows * cols
   bool hidden = false;

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -323,7 +323,7 @@ public:
   u16 cols;
   u16 rows;
   u16 id;
-  u64 winid = 0;
+  std::int64_t winid = 0;
   std::vector<GridChar> area; // Size = rows * cols
   bool hidden = false;
   std::queue<PaintEventItem> evt_q;

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -348,8 +348,9 @@ class QPaintGrid : public GridBase
     QPixmap image;
   };
 public:
-  QPaintGrid(EditorArea* ea, auto... args)
-    : GridBase(args...),
+  template<typename ...Types>
+  QPaintGrid(EditorArea* ea, Types&&... args)
+    : GridBase(std::forward<Types>(args)...),
       editor_area(ea),
       pixmap(),
       top_left(),

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -199,6 +199,7 @@ class GridBase : public QObject
 public:
   using u16 = std::uint16_t;
   using u32 = std::uint32_t;
+  using u64 = std::uint64_t;
   GridBase(
     u16 x,
     u16 y,
@@ -237,7 +238,7 @@ public:
     grid_char c,
     u16 row,
     u16 col,
-    u16 hl_id,
+    int hl_id,
     u16 repeat,
     bool is_dbl_width
   )
@@ -322,7 +323,7 @@ public:
   u16 cols;
   u16 rows;
   u16 id;
-  std::size_t z_index = 0;
+  u64 winid = 0;
   std::vector<GridChar> area; // Size = rows * cols
   bool hidden = false;
   std::queue<PaintEventItem> evt_q;

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -22,6 +22,7 @@ struct GridChar
   grid_char text;
   bool double_width = false;
   std::uint32_t ucs;
+  static grid_char grid_char_from_str(const std::string& s);
 };
 
 // Differentiate between redrawing and clearing (since clearing is

--- a/src/hlstate.cpp
+++ b/src/hlstate.cpp
@@ -10,23 +10,27 @@ namespace hl
     using u32 = std::uint32_t;
     const auto* arr = obj.array();
     assert(arr && arr->size() >= 4);
-    const int id = static_cast<int>(*arr->at(0).u64());
+    assert(arr->at(0).convertible<int>());
+    const int id = arr->at(0);
     auto* map_ptr = arr->at(1).map();
     if (!map_ptr) return {};
     const ObjectMap& map = *map_ptr;
     HLAttr attr {id};
     if (map.contains("foreground"))
     {
-      attr.foreground = static_cast<u32>(*map.at("foreground").u64());
+      assert(map.at("foreground").convertible<u32>());
+      attr.foreground = (u32) map.at("foreground");
     }
     if (map.contains("background"))
     {
-      attr.background = static_cast<u32>(*map.at("background").u64());
+      assert(map.at("background").convertible<u32>());
+      attr.background = map.at("background");
     }
     if (map.contains("reverse")) attr.reverse = true;
     if (map.contains("special"))
     {
-      attr.special = static_cast<u32>(*map.at("special").u64());
+      assert(map.at("special").convertible<u32>());
+      attr.special = (u32) map.at("special");
     }
     if (map.contains("italic")) attr.font_opts |= FontOpts::Italic;
     if (map.contains("bold")) attr.font_opts |= FontOpts::Bold;
@@ -57,15 +61,15 @@ namespace hl
       }
       if (state_map->contains("kind"))
       {
+        assert(state_map->at("kind").string());
         state.hi_name = *state_map->at("kind").string() == "syntax"
           ? Kind::Syntax
           : Kind::UI;
       }
       if (state_map->contains("id"))
       {
-        auto* id_ptr = state_map->at("id").u64();
-        assert(id_ptr);
-        state.id = *id_ptr;
+        auto id = state_map->at("id").get_as<int>();
+        if (id) state.id = *id;
       }
       attr.state.push_back(std::move(state));
     }
@@ -83,35 +87,6 @@ HLAttr::HLAttr()
 HLAttr::HLAttr(int id)
 : hl_id(id) {}
 
-HLAttr::HLAttr(const HLAttr& other)
-: hl_id(other.hl_id),
-  reverse(other.reverse),
-  special(other.special),
-  foreground(other.foreground),
-  background(other.background),
-  state(other.state),
-  opacity(other.opacity) {}
-
-HLAttr::HLAttr(HLAttr&& other)
-: hl_id(other.hl_id),
-  reverse(other.reverse),
-  special(other.special),
-  foreground(other.foreground),
-  background(other.background),
-  state(std::move(other.state)),
-  opacity(other.opacity) {}
-
-HLAttr& HLAttr::operator=(HLAttr&& other)
-{
-  hl_id = other.hl_id;
-  foreground = other.foreground;
-  background = other.background;
-  special = other.special;
-  reverse = other.reverse;
-  state = std::move(other.state);
-  opacity = other.opacity;
-  return *this;
-}
 /*
    HLState Implementation
 */

--- a/src/hlstate.cpp
+++ b/src/hlstate.cpp
@@ -12,7 +12,7 @@ namespace hl
     const auto* arr = obj.array();
     assert(arr && arr->size() >= 4);
     assert(arr->at(0).convertible<int>());
-    const int id = arr->at(0);
+    const int id = (int) arr->at(0);
     auto* map_ptr = arr->at(1).map();
     if (!map_ptr) return {};
     const ObjectMap& map = *map_ptr;
@@ -25,7 +25,7 @@ namespace hl
     if (map.contains("background"))
     {
       assert(map.at("background").convertible<u32>());
-      attr.background = map.at("background");
+      attr.background = (u32) map.at("background");
     }
     if (map.contains("reverse")) attr.reverse = true;
     if (map.contains("special"))
@@ -69,7 +69,7 @@ namespace hl
       }
       if (state_map->contains("id"))
       {
-        auto id = state_map->at("id").get_as<int>();
+        auto id = state_map->at("id").try_convert<int>();
         if (id) state.id = *id;
       }
       attr.state.push_back(std::move(state));
@@ -121,9 +121,9 @@ void HLState::default_colors_set(const Object& obj)
   // and ctermbg, which we don't care about)
   auto* arr = obj.array();
   if (!arr || arr->size() < 3) return;
-  auto fg = arr->at(0).get_as<uint32>();
-  auto bg = arr->at(1).get_as<uint32>();
-  auto sp = arr->at(2).get_as<uint32>();
+  auto fg = arr->at(0).try_convert<uint32>();
+  auto bg = arr->at(1).try_convert<uint32>();
+  auto sp = arr->at(2).try_convert<uint32>();
   assert(fg && bg && sp);
   default_colors.foreground = *fg;
   default_colors.background = *bg;

--- a/src/hlstate.cpp
+++ b/src/hlstate.cpp
@@ -48,15 +48,15 @@ namespace hl
       AttrState state;
       if (auto* hi_name = o.try_at("hi_name"); hi_name && hi_name->is_string())
       {
-        state.hi_name = hi_name->get<QString>().toStdString();
+        state.hi_name = hi_name->get<std::string>();
       }
       if (auto* ui_name = o.try_at("ui_name"); ui_name && ui_name->is_string())
       {
-        state.ui_name = ui_name->string()->toStdString();
+        state.ui_name = ui_name->get<std::string>();
       }
       if (auto* kind = o.try_at("kind"); kind && kind->is_string())
       {
-        state.hi_name = kind->get<QString>() == "syntax"
+        state.hi_name = kind->get<std::string>() == "syntax"
           ? Kind::Syntax
           : Kind::UI;
       }
@@ -170,7 +170,7 @@ void HLState::group_set(const Object& obj)
   auto* name = arr->at(0).string();
   auto* id = arr->at(1).u64();
   if (!name || !id) return;
-  auto hl_name = name->toStdString();
+  auto hl_name = *name;
   auto hl_id = static_cast<int>(*id);
   set_name_id(std::move(hl_name), hl_id);
 }

--- a/src/hlstate.cpp
+++ b/src/hlstate.cpp
@@ -115,7 +115,7 @@ void HLState::set_id_attr(int id, HLAttr attr)
   id_to_attr[id] = std::move(attr);
 }
 
-void HLState::default_colors_set(Object& obj)
+void HLState::default_colors_set(const Object& obj)
 {
   // We only look at the first three values (the others are ctermfg
   // and ctermbg, which we don't care about)
@@ -135,7 +135,7 @@ const HLAttr& HLState::default_colors_get() const
   return default_colors;
 }
 
-void HLState::define(Object& obj)
+void HLState::define(const Object& obj)
 {
   HLAttr attr = hl::hl_attr_from_object(obj);
   int id = attr.hl_id;
@@ -154,7 +154,7 @@ void HLState::define(Object& obj)
 }
 
 
-void HLState::group_set(Object& obj)
+void HLState::group_set(const Object& obj)
 {
   auto* arr = obj.array();
   assert(arr && arr->size() >= 2);

--- a/src/hlstate.cpp
+++ b/src/hlstate.cpp
@@ -46,31 +46,23 @@ namespace hl
     for(const auto& o : *info_arr)
     {
       AttrState state;
-      auto* state_map = o.map();
-      if (!state_map) continue;
-      if (state_map->contains("hi_name"))
+      if (auto* hi_name = o.try_at("hi_name"); hi_name && hi_name->is_string())
       {
-        auto* hi_name_qstr = state_map->at("hi_name").string();
-        assert(hi_name_qstr);
-        state.hi_name = hi_name_qstr->toStdString();
+        state.hi_name = hi_name->get<QString>().toStdString();
       }
-      if (state_map->contains("ui_name"))
+      if (auto* ui_name = o.try_at("ui_name"); ui_name && ui_name->is_string())
       {
-        auto* qstr = state_map->at("ui_name").string();
-        assert(qstr);
-        state.ui_name = qstr->toStdString();
+        state.ui_name = ui_name->string()->toStdString();
       }
-      if (state_map->contains("kind"))
+      if (auto* kind = o.try_at("kind"); kind && kind->is_string())
       {
-        assert(state_map->at("kind").string());
-        state.hi_name = *state_map->at("kind").string() == "syntax"
+        state.hi_name = kind->get<QString>() == "syntax"
           ? Kind::Syntax
           : Kind::UI;
       }
-      if (state_map->contains("id"))
+      if (auto* id = o.try_at("id"); id && id->convertible<int>())
       {
-        auto id = state_map->at("id").try_convert<int>();
-        if (id) state.id = *id;
+        state.id = (int) *id;
       }
       attr.state.push_back(std::move(state));
     }

--- a/src/hlstate.hpp
+++ b/src/hlstate.hpp
@@ -127,16 +127,16 @@ public:
    * Manages an "hl_attr_define" call, with obj
    * being the parameters of the call.
    */
-  void define(Object& obj);
+  void define(const Object& obj);
   /**
    * Sets the default colors.
    */
-  void default_colors_set(Object& obj);
+  void default_colors_set(const Object& obj);
   /**
    * Sets the given highlight group. This should be called with
    * the parameters of an "hl_group_set" call.
    */
-  void group_set(Object& obj);
+  void group_set(const Object& obj);
   /**
    * Returns the default colors.
    */

--- a/src/hlstate.hpp
+++ b/src/hlstate.hpp
@@ -8,12 +8,13 @@
 #include <optional>
 #include <vector>
 #include <string>
-#include <msgpack.hpp>
 #include <QColor>
+#include "object.hpp"
 
 using uint8 = std::uint8_t;
 using uint16 = std::uint16_t;
 using uint32 = std::uint32_t;
+using uint64 = std::uint64_t;
 
 enum Kind
 {
@@ -33,6 +34,8 @@ struct Color
       b((clr & 0x000000ff))
   {
   }
+  Color(int clr) : Color(static_cast<uint32>(clr)) {}
+  Color(uint64 clr) : Color(static_cast<uint32>(clr)) {}
   /**
    * Converts a Color back to a uint32
    */
@@ -45,6 +48,12 @@ struct Color
   {
     return {r, g, b};
   }
+  
+  bool operator==(const Color& other) const
+  {
+    return r == other.r && b == other.b && g == other.g;
+  }
+private:
 };
 
 struct AttrState
@@ -124,16 +133,16 @@ public:
    * Manages an "hl_attr_define" call, with obj
    * being the parameters of the call.
    */
-  void define(const msgpack::object& obj);
+  void define(Object& obj);
   /**
    * Sets the default colors.
    */
-  void default_colors_set(const msgpack::object& obj);
+  void default_colors_set(Object& obj);
   /**
    * Sets the given highlight group. This should be called with
    * the parameters of an "hl_group_set" call.
    */
-  void group_set(const msgpack::object& obj);
+  void group_set(Object& obj);
   /**
    * Returns the default colors.
    */
@@ -156,7 +165,7 @@ namespace hl
    * that were the parameters of an "hl_attr_define"
    * call.
    */
-  HLAttr hl_attr_from_object(const msgpack::object& obj);
+  HLAttr hl_attr_from_object(const Object& obj);
 }
 
 #endif

--- a/src/hlstate.hpp
+++ b/src/hlstate.hpp
@@ -136,7 +136,9 @@ public:
 class HLState
 {
 public:
-  HLState() = default;
+  HLState() {
+    id_to_attr.reserve(1000);
+  }
   /**
    * Maps name to hl_id.
    * This function maps to "hl_group_set".

--- a/src/hlstate.hpp
+++ b/src/hlstate.hpp
@@ -61,7 +61,7 @@ struct AttrState
   Kind kind;
   std::string hi_name;
   std::string ui_name;
-  uint16 id;
+  int id;
 };
 
 enum FontOpts : std::uint8_t
@@ -90,10 +90,10 @@ public:
   float opacity = 1;
   HLAttr();
   HLAttr(int id);
-  HLAttr(const HLAttr& other);
-  HLAttr(HLAttr&& other);
+  HLAttr(const HLAttr& other) = default;
+  HLAttr(HLAttr&& other) = default;
   HLAttr& operator=(const HLAttr&) = default;
-  HLAttr& operator=(HLAttr&&);
+  HLAttr& operator=(HLAttr&&) = default;
   std::optional<Color> fg() const { return foreground; }
   std::optional<Color> bg() const { return background; }
   std::optional<Color> sp() const { return special; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,13 +99,8 @@ bool is_executable(std::string_view path)
   return file_info.exists() && file_info.isExecutable();
 }
 
-Q_DECLARE_METATYPE(msgpack::object)
-Q_DECLARE_METATYPE(msgpack::object_handle*)
-
 int main(int argc, char** argv)
 {
-  qRegisterMetaType<msgpack::object>();
-  qRegisterMetaType<msgpack::object_handle*>();
   const auto args = get_args(argc, argv);
 #ifdef Q_OS_LINUX
   // See issue #21

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,9 +56,6 @@ vector<string> get_args(int argc, char** argv)
   return vector<string>(argv + 1, argv + argc);
 }
 
-Q_DECLARE_METATYPE(msgpack::object)
-Q_DECLARE_METATYPE(msgpack::object_handle*)
-
 const std::string geometry_opt = "--geometry=";
 int main(int argc, char** argv)
 {
@@ -103,8 +100,6 @@ int main(int argc, char** argv)
   int width = 100;
   int height = 50;
   std::ios_base::sync_with_stdio(false);
-  qRegisterMetaType<msgpack::object>();
-  qRegisterMetaType<msgpack::object_handle*>();
   // Get "size" option
   on_argument(args, geometry_opt, [&](std::string size_opt) {
     std::size_t pos = size_opt.find("x");

--- a/src/nvim.cpp
+++ b/src/nvim.cpp
@@ -153,12 +153,9 @@ void Nvim::read_output_sync()
     if (!msg_size) continue;
     std::string_view sv {buf, msg_size};
     std::size_t offset = 0;
-    //using Clock = std::chrono::high_resolution_clock;
-    //using dur = std::chrono::duration<double, std::milli>;
     while(offset < msg_size)
     {
       auto parsed = Object::from_msgpack(sv, offset);
-      //fmt::print("{}\n", parsed.to_string());
       auto* arr = parsed.array();
       if (!(arr && (arr->size() == 3 || arr->size() == 4))) continue;
       const auto msg_type = arr->at(0).u64();

--- a/src/nvim.cpp
+++ b/src/nvim.cpp
@@ -121,11 +121,10 @@ void Nvim::read_output_sync()
         case Type::Notification:
         {
           assert(arr->size() == 3);
-          const auto method_qstr = arr->at(1).string();
-          if (!method_qstr) continue;
-          auto method = method_qstr->toStdString();
+          const auto method_str = arr->at(1).string();
+          if (!method_str) continue;
           notification_handlers_mutex.lock();
-          const auto func_it = notification_handlers.find(method);
+          const auto func_it = notification_handlers.find(*method_str);
           if (func_it == notification_handlers.end())
           {
             notification_handlers_mutex.unlock();
@@ -141,11 +140,10 @@ void Nvim::read_output_sync()
         case Type::Request:
         {
           assert(arr->size() == 4);
-          const QString* method_qstr = arr->at(2).string();
-          if (!method_qstr) continue;
-          const auto method = method_qstr->toStdString();
+          const auto* method_str = arr->at(2).string();
+          if (!method_str) continue;
           request_handlers_mutex.lock();
-          const auto func_it = request_handlers.find(method);
+          const auto func_it = request_handlers.find(*method_str);
           if (func_it == request_handlers.end())
           {
             request_handlers_mutex.unlock();

--- a/src/nvim.cpp
+++ b/src/nvim.cpp
@@ -164,7 +164,6 @@ void Nvim::read_output_sync()
           const auto msgid = arr->at(1).u64();
           assert(msgid);
           if (!msgid) continue;
-          assert(*msgid < is_blocking.size());
           response_cb_mutex.lock();
           const auto cb_it = singleshot_callbacks.find(*msgid);
           if (cb_it != singleshot_callbacks.end())

--- a/src/nvim.hpp
+++ b/src/nvim.hpp
@@ -91,7 +91,7 @@ public:
    * Note: Only defined for values of type std::string and int.
    */
   template<typename T>
-  void set_var(const std::string& name, const T& val);
+  void set_var(const std::string& name, T&& val);
   /**
    * Sets the notification handler for the given method.
    * When a notification is sent, and the method matches the name
@@ -139,7 +139,7 @@ public:
   template<typename T>
   void send_request_cb(
     const std::string& method,
-    const T& params,
+    T&& params,
     response_cb cb
   );
   /**
@@ -181,8 +181,8 @@ public:
   template<typename Res, typename Err>
   void send_response(
     std::uint64_t msgid,
-    const Res& res,
-    const Err& err
+    Res&& res,
+    Err&& err
   );
 
   /**
@@ -214,12 +214,6 @@ private:
   std::thread out_reader;
   // Condition variable to check if we are closing
   std::atomic<bool> closed;
-  // This and last_response, along with response_mutex, are meant for
-  // performing a blocking request for the data of the response.
-  std::vector<std::uint8_t> is_blocking;
-  std::atomic<bool> response_received;
-  msgpack::object last_response;
-  std::mutex response_mutex;
   std::mutex input_mutex;
   std::mutex notification_handlers_mutex;
   std::mutex request_handlers_mutex;
@@ -233,21 +227,22 @@ private:
   boost::process::pipe stdin_pipe;
   boost::process::ipstream error;
   template<typename T>
-  void send_request(const std::string& method, const T& params, bool blocking = false);
+  void send_request(const std::string& method, T&& params);
   template<typename T>
-  void send_notification(const std::string& method, const T& params);
+  void send_notification(const std::string& method, T&& params);
   void read_output_sync();
   void read_error_sync();
 };
 
 template<typename T>
-void Nvim::send_request(const std::string& method, const T& params, bool blocking)
+void Nvim::send_request(const std::string& method, T&& params)
 {
-  is_blocking.push_back(blocking);
   std::unique_lock<std::mutex> lock {input_mutex};
   const std::uint64_t msg_type = Type::Request;
   msgpack::sbuffer sbuf;
-  const auto msg = std::make_tuple(msg_type, current_msgid, method, params);
+  const auto msg = std::tuple {
+    msg_type, current_msgid, method, std::forward<T>(params)
+  };
   msgpack::pack(sbuf, msg);
   // Potential for an exception when calling below code
   try
@@ -262,13 +257,13 @@ void Nvim::send_request(const std::string& method, const T& params, bool blockin
 }
 
 template<typename T>
-void Nvim::send_notification(const std::string& method, const T& params)
+void Nvim::send_notification(const std::string& method, T&& params)
 {
   // Same deal as Nvim::send_request, but for a notification this time
   std::unique_lock<std::mutex> lock {input_mutex};
   const std::uint64_t msg_type = Type::Notification;
   msgpack::sbuffer sbuf;
-  const auto msg = std::make_tuple(msg_type, method, params);
+  const auto msg = std::tuple {msg_type, method, std::forward<T>(params)};
   msgpack::pack(sbuf, msg);
   try
   {
@@ -283,13 +278,15 @@ void Nvim::send_notification(const std::string& method, const T& params)
 template<typename Res, typename Err>
 void Nvim::send_response(
   std::uint64_t msgid,
-  const Res& res,
-  const Err& err
+  Res&& res,
+  Err&& err
 )
 {
   std::unique_lock<std::mutex> lock {input_mutex};
   const std::uint64_t type = Type::Response;
-  const auto msg = std::tuple {type, msgid, err, res};
+  const auto msg = std::tuple {
+    type, msgid, std::forward<Err>(err), std::forward<Res>(res)
+  };
   msgpack::sbuffer sbuf;
   msgpack::pack(sbuf, msg);
   try
@@ -305,19 +302,19 @@ void Nvim::send_response(
 template<typename T>
 void Nvim::send_request_cb(
   const std::string& method,
-  const T& params,
+  T&& params,
   response_cb cb
 )
 {
   std::unique_lock<std::mutex> lock {response_cb_mutex};
   singleshot_callbacks[current_msgid] = std::move(cb);
-  send_request(method, params, false);
+  send_request(method, std::forward<T>(params));
 }
 
 template<typename T>
-void Nvim::set_var(const std::string& name, const T& val)
+void Nvim::set_var(const std::string& name, T&& val)
 {
-  send_notification("nvim_set_var", std::tuple {name, val});
+  send_notification("nvim_set_var", std::tuple {name, std::forward<T>(val)});
 }
 
 #endif

--- a/src/nvim.hpp
+++ b/src/nvim.hpp
@@ -10,6 +10,7 @@
 #include <msgpack.hpp>
 #include <atomic>
 #include <optional>
+#include "object.hpp"
 
 enum Type : std::uint64_t {
   Request = 0,
@@ -18,14 +19,14 @@ enum Type : std::uint64_t {
 };
 enum Notifications : std::uint8_t;
 enum Request : std::uint8_t;
-using msgpack_callback = std::function<void (msgpack::object_handle*)>;
+using msgpack_callback = std::function<void (Object)>;
 /// The Nvim class contains an embedded Neovim instance and
 /// some useful functions to receive output and send input
 /// using the msgpack-rpc protocol.
 class Nvim
 {
 private:
-  using response_cb = std::function<void (msgpack::object, msgpack::object)>;
+  using response_cb = std::function<void (Object, Object)>;
 public:
   ~Nvim();
   /**

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -15,7 +15,6 @@ void Object::to_stream(std::stringstream& ss) const
   std::visit(overloaded {
     [&](const std::monostate&) { ss << "null"; },
     [&](const std::string& s) { ss << '"' << s << '"'; },
-    [&](const QString& q) { ss << '\"' << q.toStdString() << '\"'; },
     [&](const int64_t& i) { ss << i; },
     [&](const uint64_t& u) { ss << u; },
     [&](const ObjectArray& v) {
@@ -163,12 +162,7 @@ struct MsgpackVisitor
 
   bool visit_str(const char* v, std::uint32_t len)
   {
-    if (in_map && !map_key_ended)
-    {
-      place(std::string(v, len));
-      return true;
-    }
-    place(QString::fromUtf8(v, static_cast<int>(len)));
+    place(std::string(v, len));
     return true;
   }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -2,6 +2,7 @@
 #include "object.hpp"
 #include <iostream>
 #include <span>
+#include <sstream>
 #include <stack>
 #include <fmt/core.h>
 #include <fmt/format.h>

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -99,7 +99,7 @@ void Object::to_stream(std::stringstream& ss) const
     [&](const Error& err) {
       ss << "Error: " << err.msg << '\n';
     }
-  }, *this);
+  }, v);
 }
 
 std::string Object::to_string() const

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1,0 +1,302 @@
+#include "msgpack_overrides.hpp"
+#include "object.hpp"
+#include <iostream>
+#include <span>
+#include <stack>
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+Object Object::parse(const msgpack::object& obj)
+{
+  using namespace msgpack::type;
+  switch(obj.type)
+  {
+    case NIL:
+      return std::monostate {};
+    case msgpack::type::BOOLEAN:
+      return obj.via.boolean;
+    case POSITIVE_INTEGER:
+      return obj.via.u64;
+    case NEGATIVE_INTEGER:
+      return obj.via.i64;
+    case STR:
+      return obj.as<QString>();
+    case BIN:
+      return obj.as<std::string>();
+    case EXT:
+    {
+      const auto& obj_ext = obj.via.ext;
+      NeovimExt ext;
+      ext.type = obj_ext.type();
+      ext.data = std::string(obj_ext.data(), obj_ext.size);
+      return ext;
+    }
+    case FLOAT32:
+    case FLOAT64:
+      return obj.as<double>();
+    case ARRAY:
+    {
+      ObjectArray vo;
+      vo.reserve(obj.via.array.size);
+      std::span s {obj.via.array.ptr, obj.via.array.size};
+      for(const auto& o : s) vo.emplace_back(parse(o));
+      return vo;
+    }
+    case MAP:
+    {
+      ObjectMap mp;
+      const auto& obj_map = obj.via.map;
+      mp.reserve(obj_map.size);
+      std::span<msgpack::object_kv> aop {obj_map.ptr, obj_map.size};
+      for(const auto& kv : aop)
+      {
+        assert(kv.key.type == msgpack::type::STR);
+        mp.emplace(kv.key.as<std::string>(), parse(kv.val));
+      }
+      return mp;
+    }
+  }
+  return std::monostate {};
+}
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+void Object::to_stream(std::stringstream& ss) const
+{
+  std::visit(overloaded {
+    [&](const std::monostate&) { ss << "null"; },
+    [&](const std::string& s) { ss << '"' << s << '"'; },
+    [&](const QString& q) { ss << '\"' << q.toStdString() << '\"'; },
+    [&](const int64_t& i) { ss << i; },
+    [&](const uint64_t& u) { ss << u; },
+    [&](const ObjectArray& v) {
+      ss << '[';
+      for(std::size_t i = 0; i < v.size() - 1 && i < v.size(); ++i)
+      {
+        v[i].to_stream(ss);
+        ss << ", ";
+      }
+      if (!v.empty()) v.back().to_stream(ss);
+      ss << ']';
+    },
+    [&](const ObjectMap& mp) {
+      ss << '{';
+      for (const auto& [k, v] : mp)
+      {
+        ss << '"' << k << "\":";
+        v.to_stream(ss);
+        ss << ", ";
+      }
+      ss << '}';
+    },
+    [&](const NeovimExt& ext) {
+      Q_UNUSED(ext);
+      ss << "EXT";
+    },
+    [&](const bool& b) { ss << b; },
+    [&](const double& d) { ss << d; },
+    [&](const QByteArray& ba) {
+      ss << '[';
+      for(int i = 0; i < ba.size() - 1; ++i)
+      {
+        ss << static_cast<std::uint8_t>(ba.at(i));
+      }
+      if (!ba.isEmpty()) ss << static_cast<std::uint8_t>(ba.back());
+      ss << ']';
+    }
+  }, *this);
+}
+
+std::string Object::to_string() const
+{
+  std::stringstream ss;
+  ss << std::boolalpha;
+  to_stream(ss);
+  return ss.str();
+}
+
+
+struct MsgpackVisitor
+{
+  enum Error
+  {
+    None,
+    InsufficentBytes,
+    Parse
+  };
+  Error error = Error::None;
+  bool map_key_ended = false;
+  Object result {};
+  Object* current = nullptr;
+  std::stack<Object*, std::vector<Object*>> stack;
+  const std::string* cur_key = nullptr;
+
+  bool start_array(std::uint32_t len)
+  {
+    stack.push(current);
+    auto* obj = place(ObjectArray());
+    assert(obj);
+    obj->get<ObjectArray>().reserve(len);
+    current = obj;
+    return true;
+  }
+
+  bool start_map(std::uint32_t len)
+  {
+    stack.push(current);
+    auto* obj = place(ObjectMap());
+    assert(obj);
+    obj->get<ObjectMap>().reserve(len);
+    current = obj;
+    map_key_ended = false; // Key goes in 1st
+    return true;
+  }
+
+  bool end_map() { pop_stack(); return true; }
+  bool end_array() { pop_stack(); return true; }
+  bool start_array_item() { return true; }
+  bool end_array_item() { return true; }
+  bool start_map_key() { map_key_ended = false; return true; }
+  bool end_map_key() { map_key_ended = true; return true; }
+  bool start_map_value() { return true; }
+  bool end_map_value() { return true; }
+
+  bool visit_nil()
+  {
+    place(std::monostate {});
+    return true;
+  }
+
+  bool visit_boolean(bool v)
+  {
+    place(v);
+    return true;
+  }
+
+  bool visit_positive_integer(std::uint64_t v)
+  {
+    place(v);
+    return true;
+  }
+
+  bool visit_negative_integer(std::int64_t v)
+  {
+    place(v);
+    return true;
+  }
+
+  bool visit_float32(float v)
+  {
+    place(double(v));
+    return true;
+  }
+
+  bool visit_float64(double v)
+  {
+    place(v);
+    return true;
+  }
+
+  bool visit_bin(const char* v, std::uint32_t size)
+  {
+    place(std::string(v, size));
+    return true;
+  }
+
+  bool visit_ext(const char* v, std::uint32_t size)
+  {
+    std::int8_t type = static_cast<int8_t>(*v);
+    place(NeovimExt {type, std::string(v + 1, size - 1)});
+    return true;
+  }
+
+
+  bool visit_str(const char* v, std::uint32_t len)
+  {
+    if (current && current->has<ObjectMap>() && !map_key_ended)
+    {
+      place(std::string(v, len));
+      return true;
+    }
+    place(QString::fromUtf8(v, static_cast<int>(len)));
+    return true;
+  }
+
+  void parse_error(std::size_t, std::size_t)
+  {
+    // Log?
+    error = Error::Parse;
+  }
+
+  void insufficient_bytes(std::size_t, std::size_t)
+  {
+    // Log?
+    error = Error::InsufficentBytes;
+  }
+
+private:
+
+  void pop_stack()
+  {
+    if (stack.empty()) return;
+    current = stack.top();
+    stack.pop();
+  }
+  
+  /// Place the arg where it should go and return a pointer to
+  /// it (most of the time).
+  template<typename T>
+  Object* place(T&& arg)
+  {
+    if (!current)
+    {
+      result = std::forward<T>(arg);
+      return &result;
+    }
+    else if (current->has<ObjectArray>())
+    {
+      return &current->get<ObjectArray>().emplace_back(std::forward<T>(arg));
+    }
+    else if (current->has<ObjectMap>())
+    {
+      auto& mp = current->get<ObjectMap>();
+      if (!cur_key)
+      {
+        if constexpr (std::is_same_v<T, std::string>)
+        {
+          auto p = mp.emplace(std::forward<T>(arg), Object());
+          cur_key = &p.first->first;
+          return nullptr;
+        }
+      }
+      else
+      {
+        assert(mp.contains(*cur_key));
+        Object* o = &mp[*cur_key];
+        *o = std::forward<T>(arg);
+        cur_key = nullptr;
+        return o;
+      }
+    }
+    return nullptr;
+  }
+};
+
+Object Object::from_msgpack(std::string_view sv, std::size_t& offset)
+{
+  MsgpackVisitor v;
+  msgpack::parse(sv.data(), sv.size(), offset, v);
+  if (v.error != MsgpackVisitor::Error::None)
+  {
+    fmt::print(
+      "Error occurred while parsing messagepack string: "
+      "{}\n",
+      v.error == MsgpackVisitor::Error::InsufficentBytes
+        ? "Insufficient Bytes" : "Parse error"
+    );
+    return Object();
+  }
+  Object o = std::move(v.result);
+  return o;
+}

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -1,0 +1,123 @@
+#ifndef NVUI_OBJECT_HPP
+#define NVUI_OBJECT_HPP
+
+#include <msgpack.hpp>
+#include <span>
+#include <string>
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <tuple>
+#include <QByteArray>
+#include <QString>
+#include <string_view>
+#include <boost/container/small_vector.hpp>
+
+struct NeovimExt
+{
+  std::int8_t type;
+  std::string data; // Preserve byte layout
+};
+
+struct Object;
+/// Neovim's Dictionary type only uses strings as keys.
+using ObjectMap = std::unordered_map<std::string, Object>;
+using ObjectArray = std::vector<Object>;
+using variant_type = std::variant<
+  std::monostate,
+  int64_t,
+  uint64_t,
+  QString,
+  ObjectArray,
+  ObjectMap,
+  bool,
+  NeovimExt,
+  std::string,
+  QByteArray,
+  double
+>;
+
+struct Object : public variant_type
+{
+  /// Parses an Object from a msgpack string.
+  /// Note: This doesn't support the full messagepack specification,
+  /// since map keys are always strings, but Neovim always specifies
+  /// keys as strings, so it works.
+  static Object from_msgpack(std::string_view sv, std::size_t& offset);
+  /// Parse from a msgpack::object from the msgpack-cpp library.
+  /// This is recursive and can get slow.
+  /// For a faster solution parse the object directly
+  /// from the serialized string using Object::from_msgpack.
+  static Object parse(const msgpack::object&);
+  std::string to_string() const;
+  auto* array() { return get_if<ObjectArray>(this); }
+  auto* string() { return get_if<QString>(this); }
+  auto* i64() { return get_if<int64_t>(this); }
+  auto* u64() { return get_if<uint64_t>(this); }
+  auto* map() { return get_if<ObjectMap>(this); }
+  auto* boolean() { return get_if<bool>(this); }
+  auto* f64() { return get_if<double>(this); }
+  auto* ext() { return get_if<NeovimExt>(this); }
+  // Const versions
+  auto* array() const { return get_if<ObjectArray>(this); }
+  auto* string() const { return get_if<QString>(this); }
+  auto* i64() const { return get_if<int64_t>(this); }
+  auto* u64() const { return get_if<uint64_t>(this); }
+  auto* map() const { return get_if<ObjectMap>(this); }
+  auto* boolean() const { return get_if<bool>(this); }
+  auto* f64() const { return get_if<double>(this); }
+  auto* ext() const { return get_if<NeovimExt>(this); }
+  bool is_null() const { return std::holds_alternative<std::monostate>(*this); }
+  template<typename T>
+  bool has() const
+  {
+    return std::holds_alternative<T>(*this);
+  }
+  template<typename T>
+  operator T() const
+  {
+    return std::visit([](const auto& val) -> T {
+      if constexpr(std::is_convertible_v<decltype(val), T>)
+      {
+        return T(val);
+      }
+      else
+      {
+        throw std::bad_variant_access();
+      }
+    }, *this);
+  }
+
+  template<typename T>
+  T& get()
+  {
+    return std::get<T>(*this);
+  }
+
+  template<typename T>
+  const T& get() const
+  {
+    return std::get<T>(*this);
+  }
+
+  template<typename T>
+  std::optional<T> get_as() const
+  {
+    using type = std::optional<T>;
+    return std::visit([](const auto& arg) -> type {
+      if constexpr(std::is_convertible_v<decltype(arg), T>)
+      {
+        return std::optional<T>(arg);
+      }
+      return std::nullopt;
+    }, *this);
+  }
+
+public:
+  using variant_type::variant_type;
+  using variant_type::operator=;
+private:
+  void to_stream(std::stringstream& ss) const;
+};
+
+#endif // NVUI_OBJECT_HPP

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -26,26 +26,30 @@ struct Error
   std::string_view msg; // Constant message
 };
 
-struct Object;
-/// Neovim's Dictionary type only uses strings as keys.
-using ObjectMap = boost::container::flat_map<std::string, Object>;
-using ObjectArray = boost::container::vector<Object>;
-using variant_type = std::variant<
-  std::monostate,
-  int64_t,
-  uint64_t,
-  QString,
-  ObjectArray,
-  ObjectMap,
-  bool,
-  NeovimExt,
-  std::string,
-  double,
-  Error
->;
-
-struct Object : public variant_type
+struct Object
 {
+  using Map = boost::container::flat_map<std::string, Object>;
+  using Array = std::vector<Object>;
+  using variant_type = std::variant<
+    std::monostate,
+    int64_t,
+    uint64_t,
+    QString,
+    Array,
+    Map,
+    bool,
+    NeovimExt,
+    std::string,
+    double,
+    Error
+  >;
+  template<typename T>
+  Object(T&& t): v(std::forward<T>(t)) {}
+  Object() = default;
+  Object(Object&&) = default;
+  Object(const Object&) = default;
+  Object& operator=(const Object&) = default;
+  Object& operator=(Object&&) = default;
   /// Parses an Object from a msgpack string.
   /// Note: This doesn't support the full messagepack specification,
   /// since map keys are always strings, but Neovim always specifies
@@ -57,31 +61,31 @@ struct Object : public variant_type
   /// from the serialized string using Object::from_msgpack.
   static Object parse(const msgpack::object&);
   std::string to_string() const;
-  auto* array() { return get_if<ObjectArray>(this); }
-  auto* string() { return get_if<QString>(this); }
-  auto* i64() { return get_if<int64_t>(this); }
-  auto* u64() { return get_if<uint64_t>(this); }
-  auto* map() { return get_if<ObjectMap>(this); }
-  auto* boolean() { return get_if<bool>(this); }
-  auto* f64() { return get_if<double>(this); }
-  auto* ext() { return get_if<NeovimExt>(this); }
-  auto* err() { return get_if<Error>(this); }
+  auto* array() { return std::get_if<Array>(&v); }
+  auto* string() { return std::get_if<QString>(&v); }
+  auto* i64() { return std::get_if<int64_t>(&v); }
+  auto* u64() { return std::get_if<uint64_t>(&v); }
+  auto* map() { return std::get_if<Map>(&v); }
+  auto* boolean() { return std::get_if<bool>(&v); }
+  auto* f64() { return std::get_if<double>(&v); }
+  auto* ext() { return std::get_if<NeovimExt>(&v); }
+  auto* err() { return std::get_if<Error>(&v); }
   // Const versions
-  auto* array() const { return get_if<ObjectArray>(this); }
-  auto* string() const { return get_if<QString>(this); }
-  auto* i64() const { return get_if<int64_t>(this); }
-  auto* u64() const { return get_if<uint64_t>(this); }
-  auto* map() const { return get_if<ObjectMap>(this); }
-  auto* boolean() const { return get_if<bool>(this); }
-  auto* f64() const { return get_if<double>(this); }
-  auto* ext() const { return get_if<NeovimExt>(this); }
-  auto* err() const { return get_if<Error>(this); }
+  auto* array() const { return std::get_if<Array>(&v); }
+  auto* string() const { return std::get_if<QString>(&v); }
+  auto* i64() const { return std::get_if<int64_t>(&v); }
+  auto* u64() const { return std::get_if<uint64_t>(&v); }
+  auto* map() const { return std::get_if<Map>(&v); }
+  auto* boolean() const { return std::get_if<bool>(&v); }
+  auto* f64() const { return std::get_if<double>(&v); }
+  auto* ext() const { return std::get_if<NeovimExt>(&v); }
+  auto* err() const { return std::get_if<Error>(&v); }
   bool is_null() const { return has<std::monostate>(); }
   bool has_err() const { return has<Error>(); }
   template<typename T>
   bool has() const
   {
-    return std::holds_alternative<T>(*this);
+    return std::holds_alternative<T>(v);
   }
   template<typename T>
   operator T() const
@@ -95,7 +99,7 @@ struct Object : public variant_type
       {
         throw std::bad_variant_access();
       }
-    }, *this);
+    }, v);
   }
 
   template<typename T>
@@ -103,7 +107,7 @@ struct Object : public variant_type
   {
     return std::visit([](const auto& val) -> bool {
       return std::is_convertible_v<decltype(val), T>;
-    }, *this);
+    }, v);
   }
 
   template<typename T>
@@ -111,19 +115,19 @@ struct Object : public variant_type
   {
     return std::visit([](const auto& v) {
       return std::is_convertible_v<decltype(v), T>;
-    }, *this);
+    }, v);
   }
 
   template<typename T>
   T& get()
   {
-    return std::get<T>(*this);
+    return std::get<T>(v);
   }
 
   template<typename T>
   const T& get() const
   {
-    return std::get<T>(*this);
+    return std::get<T>(v);
   }
 
   template<typename T>
@@ -136,19 +140,19 @@ struct Object : public variant_type
         return std::optional<T>(arg);
       }
       return std::nullopt;
-    }, *this);
+    }, v);
   }
 
   /// Decompose an Object to multiple values.
-  /// The Object you call this on must be an ObjectArray.
+  /// The Object you call this on must be an Array.
   /// If type conversion fails for any value, std::nullopt
   /// is returned.
   template<typename... T>
   std::optional<std::tuple<T...>> decompose() const
   {
-    assert(has<ObjectArray>());
+    assert(has<Array>());
     //using opt_tuple_type = std::optional<std::tuple<T...>>;
-    const auto& arr = get<ObjectArray>();
+    const auto& arr = get<Array>();
     std::tuple<T...> t;
     std::size_t idx = 0;
     bool valid = true;
@@ -164,11 +168,12 @@ struct Object : public variant_type
     return {};
   }
 
-public:
-  using variant_type::variant_type;
-  using variant_type::operator=;
 private:
   void to_stream(std::stringstream& ss) const;
+  variant_type v;
 };
+
+using ObjectArray = Object::Array;
+using ObjectMap = Object::Map;
 
 #endif // NVUI_OBJECT_HPP

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -111,14 +111,6 @@ struct Object
   }
 
   template<typename T>
-  bool is_convertible() const
-  {
-    return std::visit([](const auto& v) {
-      return std::is_convertible_v<decltype(v), T>;
-    }, v);
-  }
-
-  template<typename T>
   T& get()
   {
     return std::get<T>(v);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -11,7 +11,8 @@
 #include <QByteArray>
 #include <QString>
 #include <string_view>
-#include <boost/container/small_vector.hpp>
+#include <boost/container/vector.hpp>
+#include <boost/container/flat_map.hpp>
 
 struct NeovimExt
 {
@@ -21,8 +22,8 @@ struct NeovimExt
 
 struct Object;
 /// Neovim's Dictionary type only uses strings as keys.
-using ObjectMap = std::unordered_map<std::string, Object>;
-using ObjectArray = std::vector<Object>;
+using ObjectMap = boost::container::flat_map<std::string, Object>;
+using ObjectArray = boost::container::vector<Object>;
 using variant_type = std::variant<
   std::monostate,
   int64_t,

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -59,6 +59,7 @@ struct Object
   Object(const Object&) = default;
   Object& operator=(const Object&) = default;
   Object& operator=(Object&&) = default;
+  ~Object();
   /// Parses an Object from a msgpack string.
   /// Note: This doesn't support the full messagepack specification,
   /// since map keys are always strings, but Neovim always specifies
@@ -195,6 +196,7 @@ struct Object
   }
 
 private:
+  std::size_t children() const noexcept;
   void to_stream(std::stringstream& ss) const;
   variant_type v;
 };

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -136,13 +136,14 @@ struct Object
   }
 
   /// Decompose an Object to multiple values.
-  /// The Object you call this on must be an Array.
+  /// The Object you call this on should be an array,
+  /// otherwise std::nullopt will always be returned.
   /// If type conversion fails for any value, std::nullopt
   /// is returned.
   template<typename... T>
   std::optional<std::tuple<T...>> decompose() const
   {
-    assert(has<Array>());
+    if (!has<Array>()) return std::nullopt;
     //using opt_tuple_type = std::optional<std::tuple<T...>>;
     const auto& arr = get<Array>();
     std::tuple<T...> t;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -31,7 +31,7 @@ struct Object
   using Map = boost::container::flat_map<std::string, Object, std::less<>>;
   using Array = std::vector<Object>;
   using null_type = std::monostate;
-  using string_type = QString;
+  using string_type = std::string;
   using signed_type = std::int64_t;
   using unsigned_type = std::uint64_t;
   using array_type = Array;
@@ -41,17 +41,16 @@ struct Object
   using float_type = double;
   using err_type = Error;
   using variant_type = std::variant<
-    std::monostate,
-    int64_t,
-    uint64_t,
-    QString,
-    Array,
-    Map,
-    bool,
-    NeovimExt,
-    std::string,
-    double,
-    Error
+    null_type,
+    signed_type,
+    unsigned_type,
+    string_type,
+    array_type,
+    map_type,
+    bool_type,
+    ext_type,
+    float_type,
+    err_type
   >;
   template<typename T>
   Object(T&& t): v(std::forward<T>(t)) {}
@@ -72,7 +71,7 @@ struct Object
   static Object parse(const msgpack::object&);
   std::string to_string() const noexcept;
   auto* array() noexcept { return std::get_if<Array>(&v); }
-  auto* string() noexcept { return std::get_if<QString>(&v); }
+  auto* string() noexcept { return std::get_if<string_type>(&v); }
   auto* i64() noexcept { return std::get_if<int64_t>(&v); }
   auto* u64() noexcept { return std::get_if<uint64_t>(&v); }
   auto* map() noexcept { return std::get_if<Map>(&v); }
@@ -82,7 +81,7 @@ struct Object
   auto* err() noexcept { return std::get_if<Error>(&v); }
   // Const versions
   auto* array() const noexcept { return std::get_if<Array>(&v); }
-  auto* string() const noexcept { return std::get_if<QString>(&v); }
+  auto* string() const noexcept { return std::get_if<string_type>(&v); }
   auto* i64() const noexcept { return std::get_if<int64_t>(&v); }
   auto* u64() const noexcept { return std::get_if<uint64_t>(&v); }
   auto* map() const noexcept { return std::get_if<Map>(&v); }

--- a/src/platform/windows/direct2dpaintgrid.hpp
+++ b/src/platform/windows/direct2dpaintgrid.hpp
@@ -48,8 +48,9 @@ public:
   using d2rect = D2D1_RECT_F;
   using d2color = D2D1::ColorF;
 public:
-  D2DPaintGrid(WinEditorArea* wea, auto... args)
-    : GridBase(args...),
+  template<typename... Types>
+  D2DPaintGrid(WinEditorArea* wea, Types&&... args)
+    : GridBase(std::forward<Types>(args)...),
       editor_area(wea),
       layout_cache(2000)
   {

--- a/src/popupmenu.cpp
+++ b/src/popupmenu.cpp
@@ -145,10 +145,10 @@ void PopupMenu::pum_show(std::span<const Object> objs)
     auto* arr = obj.array();
     assert(arr && arr->size() >= 5);
     auto* items = arr->at(0).array();
-    cur_selected = arr->at(1);
-    row = arr->at(2);
-    col = arr->at(3);
-    grid_num = arr->at(4);
+    cur_selected = (int) arr->at(1);
+    row = (int) arr->at(2);
+    col = (int) arr->at(3);
+    grid_num = (int) arr->at(4);
     assert(items);
     add_items(*items);
     if (cur_selected >= 0 && cur_selected < int(completion_items.size()))

--- a/src/popupmenu.cpp
+++ b/src/popupmenu.cpp
@@ -132,7 +132,7 @@ PopupMenu::PopupMenu(const HLState* state, QWidget* parent)
   hide();
 }
 
-void PopupMenu::pum_show(std::span<Object> objs)
+void PopupMenu::pum_show(std::span<const Object> objs)
 {
   is_hidden = false;
   completion_items.clear();
@@ -160,7 +160,7 @@ void PopupMenu::pum_show(std::span<Object> objs)
   resize(available_rect().size());
 }
 
-void PopupMenu::pum_sel(std::span<Object> objs)
+void PopupMenu::pum_sel(std::span<const Object> objs)
 {
   if (objs.empty()) return;
   const auto& obj = objs.back();
@@ -172,7 +172,7 @@ void PopupMenu::pum_sel(std::span<Object> objs)
   paint();
 }
 
-void PopupMenu::pum_hide(std::span<Object> objs)
+void PopupMenu::pum_hide(std::span<const Object> objs)
 {
   Q_UNUSED(objs);
   is_hidden = true;
@@ -180,9 +180,9 @@ void PopupMenu::pum_hide(std::span<Object> objs)
   info_widget.hide();
 }
 
-void PopupMenu::add_items(ObjectArray& items)
+void PopupMenu::add_items(const ObjectArray& items)
 {
-  for(auto& item : items)
+  for(const auto& item : items)
   {
     auto* arr = item.array();
     assert(arr && arr->size() >= 4);
@@ -192,9 +192,7 @@ void PopupMenu::add_items(ObjectArray& items)
     auto* info = arr->at(3).string();
     assert(word && kind && menu && info);
     completion_items.push_back({
-      false,
-      std::move(*word), std::move(*kind),
-      std::move(*menu),std::move(*info)
+      false, *word, *kind, *menu,*info
     });
   }
 }

--- a/src/popupmenu.cpp
+++ b/src/popupmenu.cpp
@@ -183,13 +183,13 @@ void PopupMenu::add_items(const ObjectArray& items)
   {
     auto* arr = item.array();
     assert(arr && arr->size() >= 4);
-    auto* word = arr->at(0).string();
-    auto* kind = arr->at(1).string();
-    auto* menu = arr->at(2).string();
-    auto* info = arr->at(3).string();
+    auto word = QString::fromStdString(*arr->at(0).string());
+    auto kind = QString::fromStdString(*arr->at(1).string());
+    auto menu = QString::fromStdString(*arr->at(2).string());
+    auto info = QString::fromStdString(arr->at(3).get<std::string>());
     assert(word && kind && menu && info);
     completion_items.push_back({
-      false, *word, *kind, *menu,*info
+      false, std::move(word), std::move(kind), std::move(menu), std::move(info)
     });
   }
 }

--- a/src/popupmenu.cpp
+++ b/src/popupmenu.cpp
@@ -186,8 +186,7 @@ void PopupMenu::add_items(const ObjectArray& items)
     auto word = QString::fromStdString(*arr->at(0).string());
     auto kind = QString::fromStdString(*arr->at(1).string());
     auto menu = QString::fromStdString(*arr->at(2).string());
-    auto info = QString::fromStdString(arr->at(3).get<std::string>());
-    assert(word && kind && menu && info);
+    auto info = QString::fromStdString(*arr->at(3).string());
     completion_items.push_back({
       false, std::move(word), std::move(kind), std::move(menu), std::move(info)
     });

--- a/src/popupmenu.hpp
+++ b/src/popupmenu.hpp
@@ -206,17 +206,17 @@ public:
    * Handles a Neovim "popupmenu_show" event, showing the popupmenu with the
    * given items.
    */
-  void pum_show(std::span<Object> objs);
+  void pum_show(std::span<const Object> objs);
   /**
    * Hides the popupmenu.
    */
-  void pum_hide(std::span<Object> objs);
+  void pum_hide(std::span<const Object> objs);
   /**
    * Handles a Neovim "popupmenu_select" event, selecting the
    * popupmenu item at the given index,
    * or selecting nothing if the index is -1.
    */
-  void pum_sel(std::span<Object> objs);
+  void pum_sel(std::span<const Object> objs);
   /**
    * Update the highlight attributes used for drawing the popup menu.
    */
@@ -363,7 +363,7 @@ private:
   /**
    * Add the given popupmenu items to the popup menu.
    */
-  void add_items(ObjectArray& items);
+  void add_items(const ObjectArray& items);
   /**
    * Redraw the popupmenu.
    */

--- a/src/popupmenu.hpp
+++ b/src/popupmenu.hpp
@@ -6,8 +6,10 @@
 #include <QDebug>
 #include <QPaintEvent>
 #include <QStringBuilder>
+#include <span>
 #include <msgpack.hpp>
 #include "hlstate.hpp"
+#include "object.hpp"
 #include "utils.hpp"
 #include <fmt/core.h>
 #include <fmt/format.h>
@@ -87,6 +89,13 @@ public:
     return vs;
   }
 
+  const QColor* bg_for_kind(const QString& kind) const
+  {
+    if (!colors.contains(kind)) return nullptr;
+    const auto& clr = colors[kind].second;
+    if (!clr) return &default_bg;
+    return &*clr;
+  }
 private:
   QPixmap load_icon(const QString& iname, int width);
   void load_icons(int width);
@@ -197,17 +206,17 @@ public:
    * Handles a Neovim "popupmenu_show" event, showing the popupmenu with the
    * given items.
    */
-  void pum_show(const msgpack::object* obj, std::uint32_t size);
+  void pum_show(std::span<Object> objs);
   /**
    * Hides the popupmenu.
    */
-  void pum_hide(const msgpack::object* obj, std::uint32_t size = 1);
+  void pum_hide(std::span<Object> objs);
   /**
    * Handles a Neovim "popupmenu_select" event, selecting the
    * popupmenu item at the given index,
    * or selecting nothing if the index is -1.
    */
-  void pum_sel(const msgpack::object* obj, std::uint32_t size = 1);
+  void pum_sel(std::span<Object> objs);
   /**
    * Update the highlight attributes used for drawing the popup menu.
    */
@@ -352,7 +361,7 @@ private:
   /**
    * Add the given popupmenu items to the popup menu.
    */
-  void add_items(const msgpack::object_array& items);
+  void add_items(ObjectArray& items);
   /**
    * Redraw the popupmenu.
    */

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -146,4 +146,14 @@ void wait_for_value(std::atomic<T>& v, T val)
   while(v != val) {}
 }
 
+
+// find or default for map containers
+template<typename Map, typename K, typename V>
+V find_or_default(const Map& m, const K& k, const V& v)
+{
+  auto it = m.find(k);
+  if (it == m.end()) return v;
+  return it->second;
+}
+
 #endif // NVUI_UTILS_HPP

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -164,6 +164,8 @@ void for_each_in_tuple(std::tuple<Types...>& t, Func&& f)
   if constexpr(idx != sizeof...(Types) - 1)
   {
     for_each_in_tuple<idx + 1>(t, std::forward<Func>(f));
+  }
+}
 
 /// UCS2-aware string reversal
 inline void reverse_qstring(QString& s)

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -156,4 +156,15 @@ V find_or_default(const Map& m, const K& k, const V& v)
   return it->second;
 }
 
+template<std::size_t idx = 0, typename... Types, typename Func>
+void for_each_in_tuple(std::tuple<Types...>& t, Func&& f)
+{
+  constexpr auto s = std::integral_constant<std::size_t, idx> {};
+  f(std::get<s>(t));
+  if constexpr(idx != sizeof...(Types) - 1)
+  {
+    for_each_in_tuple<idx + 1>(t, std::forward<Func>(f));
+  }
+}
+
 #endif // NVUI_UTILS_HPP

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -68,7 +68,7 @@ static std::function<void (const ObjectArray&)> paramify(Func f)
     std::size_t idx = 0;
     for_each_in_tuple(t, [&](auto& p) {
       using val_type = std::remove_reference_t<decltype(p)>;
-      std::optional<val_type> v = arg_list.at(idx).get_as<val_type>();
+      std::optional<val_type> v = arg_list.at(idx).try_convert<val_type>();
       if (!v) { valid = false; return; }
       p = *v;
       ++idx;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -266,6 +266,7 @@ void Window::register_handlers()
         handle_redraw(std::move(o));
       }
     );
+  });
   using notification = const ObjectArray&;
   listen_for_notification("NVUI_WINOPACITY", paramify<float>([this](double opacity) {
     if (opacity <= 0.0 || opacity > 1.0) return;
@@ -745,14 +746,14 @@ void Window::handle_request(
           if (!msgid || !params) return;
           std::optional<Res> res;
           std::optional<Err> err;
-          std::tie(res, err) = f(params_obj.via.array);
+          std::tie(res, err) = f(*arr);
           if (res)
           {
-            nvim->send_response(msgid, *res, msgpack::object());
+            nvim->send_response(*msgid, *res, msgpack::object());
           }
           else
           {
-            nvim->send_response(msgid, msgpack::object(), *err);
+            nvim->send_response(*msgid, msgpack::object(), *err);
           }
         },
         Qt::QueuedConnection

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -148,13 +148,13 @@ void Window::register_handlers()
 {
   // Set GUI handlers before we set the notification handler (since Nvim runs on a different thread,
   // it can be called any time)
-  set_handler("hl_attr_define", [](Window* w,std::span<Object> objs) {
-    for(auto& obj : objs) w->hl_state.define(obj);
+  set_handler("hl_attr_define", [](Window* w, std::span<const Object> objs) {
+    for(const auto& obj : objs) w->hl_state.define(obj);
   });
-  set_handler("hl_group_set", [](Window* w, std::span<Object> objs) {
-    for (auto& obj : objs) w->hl_state.group_set(obj);
+  set_handler("hl_group_set", [](Window* w, std::span<const Object> objs) {
+    for (const auto& obj : objs) w->hl_state.group_set(obj);
   });
-  set_handler("default_colors_set", [](Window* w, std::span<Object> objs) {
+  set_handler("default_colors_set", [](Window* w, std::span<const Object> objs) {
     if (objs.empty()) return;
     w->hl_state.default_colors_set(objs.back());
     const HLAttr& def_clrs = w->hl_state.default_colors_get();
@@ -162,99 +162,99 @@ void Window::register_handlers()
     auto bg = def_clrs.bg()->qcolor();
     emit w->default_colors_changed(fg, bg);
   });
-  set_handler("grid_line", [](Window* w, std::span<Object> objs) {
+  set_handler("grid_line", [](Window* w, std::span<const Object> objs) {
     w->editor_area.grid_line(objs);
   });
-  set_handler("option_set", [](Window* w, std::span<Object> objs) {
+  set_handler("option_set", [](Window* w, std::span<const Object> objs) {
     w->editor_area.option_set(objs);
   });
-  set_handler("grid_resize", [](Window* w, std::span<Object> objs) {
+  set_handler("grid_resize", [](Window* w, std::span<const Object> objs) {
     w->editor_area.grid_resize(objs);
   });
-  set_handler("flush", [](Window* w, std::span<Object> objs) {
+  set_handler("flush", [](Window* w, std::span<const Object> objs) {
     Q_UNUSED(objs);
     w->editor_area.flush();
   });
-  set_handler("win_pos", [](Window* w, std::span<Object> objs) {
+  set_handler("win_pos", [](Window* w, std::span<const Object> objs) {
     w->editor_area.win_pos(objs);
   });
-  set_handler("grid_clear", [](Window* w, std::span<Object> objs) {
+  set_handler("grid_clear", [](Window* w, std::span<const Object> objs) {
     w->editor_area.grid_clear(objs);
   });
-  set_handler("grid_cursor_goto", [](Window* w, std::span<Object> objs) {
+  set_handler("grid_cursor_goto", [](Window* w, std::span<const Object> objs) {
     w->editor_area.grid_cursor_goto(objs);
   });
-  set_handler("grid_scroll", [](Window* w, std::span<Object> objs) {
+  set_handler("grid_scroll", [](Window* w, std::span<const Object> objs) {
     w->editor_area.grid_scroll(objs);
   });
-  set_handler("mode_info_set", [](Window* w, std::span<Object> objs) {
+  set_handler("mode_info_set", [](Window* w, std::span<const Object> objs) {
     w->editor_area.mode_info_set(objs);
   });
-  set_handler("mode_change", [](Window* w, std::span<Object> objs) {
+  set_handler("mode_change", [](Window* w, std::span<const Object> objs) {
     w->editor_area.mode_change(objs);
   });
-  set_handler("popupmenu_show", [](Window* w, std::span<Object> objs) {
+  set_handler("popupmenu_show", [](Window* w, std::span<const Object> objs) {
     w->editor_area.popupmenu_show(objs);
   });
-  set_handler("popupmenu_hide", [](Window* w, std::span<Object> objs) {
+  set_handler("popupmenu_hide", [](Window* w, std::span<const Object> objs) {
     w->editor_area.popupmenu_hide(objs);
   });
-  set_handler("popupmenu_select", [](Window* w, std::span<Object> objs) {
+  set_handler("popupmenu_select", [](Window* w, std::span<const Object> objs) {
     w->editor_area.popupmenu_select(objs);
   });
-  set_handler("busy_start", [](Window* w, std::span<Object> objs) {
+  set_handler("busy_start", [](Window* w, std::span<const Object> objs) {
     Q_UNUSED(objs);
     w->editor_area.busy_start();
   });
-  set_handler("busy_stop", [](Window* w, std::span<Object> objs) {
+  set_handler("busy_stop", [](Window* w, std::span<const Object> objs) {
     Q_UNUSED(objs);
     w->editor_area.busy_stop();
   });
-  set_handler("cmdline_show", [](Window* w, std::span<Object> objs) {
+  set_handler("cmdline_show", [](Window* w, std::span<const Object> objs) {
     w->editor_area.cmdline_show(objs);
   });
-  set_handler("cmdline_hide", [](Window* w, std::span<Object> objs) {
+  set_handler("cmdline_hide", [](Window* w, std::span<const Object> objs) {
     w->editor_area.cmdline_hide(objs);
   });
-  set_handler("cmdline_pos", [](Window* w, std::span<Object> objs) {
+  set_handler("cmdline_pos", [](Window* w, std::span<const Object> objs) {
     w->editor_area.cmdline_cursor_pos(objs);
   });
-  set_handler("cmdline_special_char", [](Window* w, std::span<Object> objs) {
+  set_handler("cmdline_special_char", [](Window* w, std::span<const Object> objs) {
     w->editor_area.cmdline_special_char(objs);
   });
-  set_handler("cmdline_block_show", [](Window* w, std::span<Object> objs) {
+  set_handler("cmdline_block_show", [](Window* w, std::span<const Object> objs) {
     w->editor_area.cmdline_block_show(objs);
   });
-  set_handler("cmdline_block_append", [](Window* w, std::span<Object> objs) {
+  set_handler("cmdline_block_append", [](Window* w, std::span<const Object> objs) {
     w->editor_area.cmdline_block_append(objs);
   });
-  set_handler("cmdline_block_hide", [](Window* w, std::span<Object> objs) {
+  set_handler("cmdline_block_hide", [](Window* w, std::span<const Object> objs) {
     w->editor_area.cmdline_block_hide(objs);
   });
-  set_handler("mouse_on", [](Window* w, std::span<Object> objs) {
+  set_handler("mouse_on", [](Window* w, std::span<const Object> objs) {
     Q_UNUSED(objs);
     w->editor_area.set_mouse_enabled(true);
   });
-  set_handler("mouse_off", [](Window* w, std::span<Object> objs) {
+  set_handler("mouse_off", [](Window* w, std::span<const Object> objs) {
     Q_UNUSED(objs);
     w->editor_area.set_mouse_enabled(false);
   });
-  set_handler("win_hide", [](Window* w, std::span<Object> objs) {
+  set_handler("win_hide", [](Window* w, std::span<const Object> objs) {
     w->editor_area.win_hide(objs);
   });
-  set_handler("win_float_pos", [](Window* w, std::span<Object> objs) {
+  set_handler("win_float_pos", [](Window* w, std::span<const Object> objs) {
     w->editor_area.win_float_pos(objs);
   });
-  set_handler("win_close", [](Window* w, std::span<Object> objs) {
+  set_handler("win_close", [](Window* w, std::span<const Object> objs) {
     w->editor_area.win_close(objs);
   });
-  set_handler("grid_destroy", [](Window* w, std::span<Object> objs) {
+  set_handler("grid_destroy", [](Window* w, std::span<const Object> objs) {
     w->editor_area.grid_destroy(objs);
   });
-  set_handler("msg_set_pos", [](Window* w, std::span<Object> objs) {
+  set_handler("msg_set_pos", [](Window* w, std::span<const Object> objs) {
     w->editor_area.msg_set_pos(objs);
   });
-  set_handler("win_viewport", [](Window* w, std::span<Object> objs) {
+  set_handler("win_viewport", [](Window* w, std::span<const Object> objs) {
     w->editor_area.win_viewport(objs);
   });
   // The lambda will get invoked on the Nvim::read_output thread, we use

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -48,17 +48,6 @@ static void windows_setup_frameless(HWND hwnd)
 
 using u32 = std::uint32_t;
 
-template<std::size_t idx = 0, typename... Types, typename Func>
-void for_each_in_tuple(std::tuple<Types...>& t, Func&& f)
-{
-  constexpr auto s = std::integral_constant<std::size_t, idx> {};
-  f(std::get<s>(t));
-  if constexpr(idx != sizeof...(Types) - 1)
-  {
-    for_each_in_tuple<idx + 1>(t, std::forward<Func>(f));
-  }
-}
-
 /**
  * Automatically unpack ObjectArray into the desired parameters,
  * or exit if it doesn't match.
@@ -114,8 +103,6 @@ Window::Window(QWidget* parent, std::shared_ptr<Nvim> nv, int width, int height)
 
 void Window::handle_redraw(Object redraw_args)
 {
-  //fmt::print("{}\n", redraw_args.to_string());
-  //std::stringstream ss;
   auto* arr = redraw_args.array();
   assert(arr && arr->size() >= 3);
   auto* args = arr->at(2).array();
@@ -127,7 +114,6 @@ void Window::handle_redraw(Object redraw_args)
     auto* task_qstr = task->at(0).string();
     if (!task_qstr) continue;
     auto task_name = task_qstr->toStdString();
-    //fmt::print("Current task: {}\n", task_name);
     const auto func_it = handlers.find(task_name);
     if (func_it != handlers.end())
     {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -759,8 +759,8 @@ void Window::handle_request(
           if (!msgid || !params) return;
           std::optional<Res> res;
           std::optional<Err> err;
-          std::tie(res, err) = f(params_obj.via.array);
-          nvim->send_response(msgid, res, err);
+          std::tie(res, err) = f(*params);
+          nvim->send_response(*msgid, res, err);
         },
         Qt::QueuedConnection
       );

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -14,6 +14,7 @@
 #include "hlstate.hpp"
 #include <iostream>
 #include <memory>
+#include <span>
 #include <msgpack.hpp>
 #include <QEvent>
 #include <unordered_map>
@@ -26,7 +27,7 @@ class Window;
 
 constexpr int tolerance = 10; //10px tolerance for resizing
 
-using obj_ref_cb = std::function<void (const msgpack::object*, std::uint32_t size)>;
+using obj_ref_cb = void (*)(Window*, std::span<Object>);
 
 /// The main window class which holds the rest of the GUI components.
 /// Fundamentally, the Neovim area is just 1 big text box.
@@ -39,7 +40,7 @@ class Window : public QMainWindow
   using handler_func =
     std::function<
       std::tuple<std::optional<R>, std::optional<E>>
-      (const msgpack::object_array&)>;
+      (const ObjectArray&)>;
 public:
   Window(QWidget* parent = nullptr, std::shared_ptr<Nvim> nv = nullptr, int width = 0, int height = 0);
   /**
@@ -59,7 +60,7 @@ public slots:
    * TODO: Decide parameter type and how this will be called
    * (signals etc.)
    */
-  void handle_redraw(msgpack::object_handle* dir_args);
+  void handle_redraw(Object dir_args);
   /**
    * Starts a resizing or moving operation depending on the coordinates
    * of p.
@@ -69,14 +70,14 @@ public slots:
    * Handles a Neovim 'BufEnter' event, updating the titlebar with the
    * current file.
    */
-  void handle_bufenter(msgpack::object_handle* dir_args);
+  void handle_bufenter(Object dir_args);
   /**
    * Handles a Neovim 'DirChanged' event
    * Some things this would probably do would be:
    * 1. Updating the titlebar text
    * 2. Updating a file tree (if it ever gets added)
    */
-  void dirchanged_titlebar(msgpack::object_handle* dir_args);
+  void dirchanged_titlebar(Object dir_args);
   /**
    * Returns whether the window is frameless or not
    */
@@ -91,30 +92,13 @@ public slots:
   void maximize();
 private:
   /**
-   * Wraps func around a blocking semaphore.
-   * When the returned function is called, the executing thread
-   * will be paused until the semaphore is released on a separate thread.
-   * (This is executed on the Neovim thread so that Qt thread has time to copy data)
-   * See nvim.hpp for msgpack_callback
-   */
-  msgpack_callback sem_block(msgpack_callback func);
-  /**
-   * Deep-copies obj, returning its object handle, and releases the
-   * semaphore.
-   * Inside of the function called by the notification handler,
-   * this should be the FIRST thing called, since the Nvim thread is
-   * waiting for the semaphore to release to continue its execution.
-   */
-  msgpack::object_handle safe_copy(msgpack::object_handle* obj);
-  /**
    * Listen for a notification with the method call "method",
    * and invoke the corresponding callback on the main (Qt) thread.
-   * msgpack::object_handle moving is already done, so the lambdas
-   * passed just have to deal with their logic.
+   * cb is passed the arguments array.
    */
   void listen_for_notification(
     std::string method,
-    std::function<void (const msgpack::object_array&)> cb
+    std::function<void (const ObjectArray&)> cb
   );
   /**
    * Listens for a request with the given name,

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -27,7 +27,7 @@ class Window;
 
 constexpr int tolerance = 10; //10px tolerance for resizing
 
-using obj_ref_cb = void (*)(Window*, std::span<Object>);
+using obj_ref_cb = void (*)(Window*, std::span<const Object>);
 
 /// The main window class which holds the rest of the GUI components.
 /// Fundamentally, the Neovim area is just 1 big text box.

--- a/test/test_default_colors.cpp
+++ b/test/test_default_colors.cpp
@@ -1,9 +1,12 @@
 #include <catch2/catch.hpp>
 #include <sstream>
 #include "hlstate.hpp"
+#include "object.hpp"
+#include <unordered_map>
 
 TEST_CASE("default_colors are set properly", "[default_colors_set]")
 {
+  using namespace std::string_literals;
   HLState hl_state;
   // Params of "default_colors_set"
   SECTION("default_colors_set: Test #1")
@@ -18,7 +21,8 @@ TEST_CASE("default_colors are set properly", "[default_colors_set]")
     packer.pack(0); // cterm bg
     const auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
     const msgpack::object& obj = oh.get();
-    hl_state.default_colors_set(obj);
+    auto parsed = Object::parse(obj);
+    hl_state.default_colors_set(parsed);
     const auto& def = hl_state.default_colors_get();
     REQUIRE(def.fg());
     REQUIRE(def.bg());

--- a/test/test_hl_attr_from_object.cpp
+++ b/test/test_hl_attr_from_object.cpp
@@ -29,6 +29,6 @@ TEST_CASE("hl_attr_from_object works", "[hl_attr_from_object]")
     REQUIRE(resulting_attr.hl_id == 107);
     REQUIRE(!resulting_attr.bg().has_value());
     REQUIRE(resulting_attr.fg().has_value());
-    REQUIRE(resulting_attr.fg().value() == Color(rgb));
+    REQUIRE(resulting_attr.fg().value().to_uint32() == rgb);
   }
 }

--- a/test/test_hl_attr_from_object.cpp
+++ b/test/test_hl_attr_from_object.cpp
@@ -1,34 +1,34 @@
+#include "object.hpp"
 #include "hlstate.hpp"
 #include <catch2/catch.hpp>
 #include <msgpack.hpp>
+#include <iostream>
 #include <sstream>
+
 TEST_CASE("hl_attr_from_object works", "[hl_attr_from_object]")
 {
   SECTION("Works for standard data examples taken from Neovim messages")
   {
-    // TODO: Save data from Neovim messages so that we can reuse them in tests.
-    // Writing a bunch of pack commands is not very fun.
-    std::stringstream ss;
-    msgpack::packer<std::stringstream> packer {ss};
-    packer.pack_array(4);
-    packer.pack_int32(107);
-    packer.pack_map(2);
-    packer.pack("italic");
-    packer.pack(true);
-    packer.pack("foreground");
-    packer.pack(16753826);
-    packer.pack_map(0);
-    packer.pack_array(1);
-    packer.pack_map(3);
-    packer.pack("kind");
-    packer.pack("syntax");
-    packer.pack("hi_name");
-    packer.pack("TSParameter");
-    packer.pack("id");
-    packer.pack(107);
-    const auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
-    const auto& obj = oh.get();
-    const HLAttr resulting_attr = hl::hl_attr_from_object(obj);
+    uint64 rgb = 16753826;
+    Object o = ObjectArray {
+      107,
+      ObjectMap {
+        {"italic", true},
+        {"foreground", rgb}
+      },
+      ObjectMap {},
+      ObjectArray {
+        ObjectMap {
+          {"kind", QString("syntax")},
+          {"hi_name", QString("TSParameter")},
+          {"id", 107}
+        }
+      }
+    };
+    const HLAttr resulting_attr = hl::hl_attr_from_object(o);
     REQUIRE(resulting_attr.hl_id == 107);
+    REQUIRE(!resulting_attr.bg().has_value());
+    REQUIRE(resulting_attr.fg().has_value());
+    REQUIRE(resulting_attr.fg().value() == Color(rgb));
   }
 }

--- a/test/test_hl_attr_from_object.cpp
+++ b/test/test_hl_attr_from_object.cpp
@@ -11,7 +11,7 @@ TEST_CASE("hl_attr_from_object works", "[hl_attr_from_object]")
   {
     uint64 rgb = 16753826;
     Object o = ObjectArray {
-      107,
+      uint64(107),
       ObjectMap {
         {"italic", true},
         {"foreground", rgb}
@@ -21,7 +21,7 @@ TEST_CASE("hl_attr_from_object works", "[hl_attr_from_object]")
         ObjectMap {
           {"kind", QString("syntax")},
           {"hi_name", QString("TSParameter")},
-          {"id", 107}
+          {"id", uint64(107)}
         }
       }
     };

--- a/test/test_hl_attr_from_object.cpp
+++ b/test/test_hl_attr_from_object.cpp
@@ -19,8 +19,8 @@ TEST_CASE("hl_attr_from_object works", "[hl_attr_from_object]")
       ObjectMap {},
       ObjectArray {
         ObjectMap {
-          {"kind", QString("syntax")},
-          {"hi_name", QString("TSParameter")},
+          {"kind", std::string("syntax")},
+          {"hi_name", std::string("TSParameter")},
           {"id", uint64(107)}
         }
       }

--- a/test/test_nvim_eval.cpp
+++ b/test/test_nvim_eval.cpp
@@ -6,9 +6,8 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include "object.hpp"
 
-using obj = msgpack::object;
-using obj_handle = msgpack::object_handle;
 using namespace std::chrono_literals;
 
 TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
@@ -18,10 +17,10 @@ TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
   SECTION("Evaluating math")
   {
     std::atomic<bool> done = false;
-    nvim.eval_cb("1 + 2", [&](obj res, obj err) {
-      REQUIRE(err.is_nil());
-      REQUIRE(res.type == msgpack::type::POSITIVE_INTEGER);
-      REQUIRE(res.as<int>() == 3);
+    nvim.eval_cb("1 + 2", [&](Object res, Object err) {
+      REQUIRE(err.is_null());
+      REQUIRE(res.get_as<int>());
+      REQUIRE(*res.get_as<int>() == 3);
       done = true;
     });
     wait_for_value(done, true);
@@ -29,9 +28,9 @@ TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
   SECTION("Can evaluate variables")
   {
     std::atomic<bool> done = false;
-    nvim.eval_cb("stdpath('config')", [&](obj res, obj err) {
-      REQUIRE(err.is_nil());
-      REQUIRE(res.type == msgpack::type::STR);
+    nvim.eval_cb("stdpath('config')", [&](Object res, Object err) {
+      REQUIRE(err.is_null());
+      REQUIRE(res.string());
       done = true;
     });
     wait_for_value(done, true);
@@ -39,9 +38,9 @@ TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
   SECTION("Will send errors in the 'err' parameter")
   {
     std::atomic<bool> done = false;
-    nvim.eval_cb("stdpath", [&](obj res, obj err) {
-      REQUIRE(res.is_nil());
-      REQUIRE(!err.is_nil());
+    nvim.eval_cb("stdpath", [&](Object res, Object err) {
+      REQUIRE(res.is_null());
+      REQUIRE(!err.is_null());
       done = true;
     });
     wait_for_value(done, true);

--- a/test/test_nvim_eval.cpp
+++ b/test/test_nvim_eval.cpp
@@ -19,8 +19,8 @@ TEST_CASE("nvim_eval callbacks work", "[eval_cb]")
     std::atomic<bool> done = false;
     nvim.eval_cb("1 + 2", [&](Object res, Object err) {
       REQUIRE(err.is_null());
-      REQUIRE(res.get_as<int>());
-      REQUIRE(*res.get_as<int>() == 3);
+      REQUIRE(res.try_convert<int>());
+      REQUIRE(*res.try_convert<int>() == 3);
       done = true;
     });
     wait_for_value(done, true);

--- a/test/test_nvim_set_var.cpp
+++ b/test/test_nvim_set_var.cpp
@@ -12,22 +12,22 @@ TEST_CASE("nvim_set_var sets variables properly", "[nvim_set_var]")
 {
   using std::this_thread::sleep_for;
   using namespace std::chrono_literals;
-  using obj = msgpack::object;
   // One thing to note: nvim_set_var only works for setting strings and ints
   // (as is said in the header file). However it's just a template method
   // so adding more types is as easy as adding more declarations in the cpp file.
-  auto nvim = std::make_shared<Nvim>();
-  REQUIRE(nvim->running());
+  Nvim nvim;
+  REQUIRE(nvim.running());
   SECTION("nvim_set_var works for ints")
   {
     std::atomic<bool> done = false;
-    nvim->set_var("uniquevariable", 253);
+    nvim.set_var("uniquevariable", 253);
     // Neovim sets a global (g:) variable with the name we gave,
     // so we can get the result from an nvim_eval command.
-    nvim->eval_cb("g:uniquevariable", [&](obj res, obj err) {
-      REQUIRE(err.is_nil());
-      REQUIRE(res.type == msgpack::type::POSITIVE_INTEGER);
-      REQUIRE(res.as<int>() == 253);
+    nvim.eval_cb("g:uniquevariable", [&](Object res, Object err) {
+      REQUIRE(err.is_null());
+      auto result = res.get_as<int>();
+      REQUIRE(result);
+      REQUIRE(*result == 253);
       done = true;
     });
     wait_for_value(done, true);
@@ -35,11 +35,12 @@ TEST_CASE("nvim_set_var sets variables properly", "[nvim_set_var]")
   SECTION("nvim_set_var works for strings")
   {
     std::atomic<bool> done = false;
-    nvim->set_var("uniquevariabletwo", std::string("doesthiswork"));
-    nvim->eval_cb("g:uniquevariabletwo", [&](obj res, obj err) {
-      REQUIRE(err.is_nil());
-      REQUIRE(res.type == msgpack::type::STR);
-      REQUIRE(res.as<std::string>() == "doesthiswork");
+    nvim.set_var("uniquevariabletwo", std::string("doesthiswork"));
+    nvim.eval_cb("g:uniquevariabletwo", [&](Object res, Object err) {
+      REQUIRE(err.is_null());
+      auto str = res.string();
+      REQUIRE(str);
+      REQUIRE(*str == "doesthiswork");
       done = true;
     });
     wait_for_value(done, true);

--- a/test/test_nvim_set_var.cpp
+++ b/test/test_nvim_set_var.cpp
@@ -25,7 +25,7 @@ TEST_CASE("nvim_set_var sets variables properly", "[nvim_set_var]")
     // so we can get the result from an nvim_eval command.
     nvim.eval_cb("g:uniquevariable", [&](Object res, Object err) {
       REQUIRE(err.is_null());
-      auto result = res.get_as<int>();
+      auto result = res.try_convert<int>();
       REQUIRE(result);
       REQUIRE(*result == 253);
       done = true;

--- a/test/test_object.cpp
+++ b/test/test_object.cpp
@@ -34,8 +34,8 @@ TEST_CASE("Object parsing works", "[Object]")
     msgpack::object_handle oh = pack_unpack(s);
     const auto& o = oh.get();
     auto parsed = Object::parse(o);
-    REQUIRE(parsed.has<QString>());
-    REQUIRE(parsed.get<QString>() == s.c_str());
+    REQUIRE(parsed.has<std::string>());
+    REQUIRE(parsed.get<std::string>() == s.c_str());
   }
   SECTION("Arrays")
   {
@@ -68,9 +68,9 @@ TEST_CASE("Object parsing works", "[Object]")
       const auto& omap = parsed.get<ObjectArray>();
       for(std::size_t i = 0; i < omap.size(); ++i)
       {
-        using val_type = QString;
+        using val_type = std::string;
         REQUIRE(omap.at(i).has<val_type>());
-        REQUIRE(omap.at(i).get<val_type>() == QString::fromStdString(v.at(i)));
+        REQUIRE(omap.at(i).get<val_type>() == v.at(i));
       }
     }
   }
@@ -94,8 +94,7 @@ TEST_CASE("Object parsing works", "[Object]")
     for(const auto& [key, val] : omap)
     {
       REQUIRE(mp.contains(key));
-      // string type gets parsed to QString
-      REQUIRE(val.has<QString>());
+      REQUIRE(val.has<std::string>());
     }
   }
 }
@@ -128,10 +127,10 @@ TEST_CASE("Extracting types from Object")
   }
   SECTION("Optional function works")
   {
-    Object o = QString("hello world");
-    auto qstr_opt = o.try_convert<QString>();
-    REQUIRE(qstr_opt);
-    REQUIRE(*qstr_opt == "hello world");
+    Object o = std::string("hello world");
+    auto str_opt = o.try_convert<std::string>();
+    REQUIRE(str_opt);
+    REQUIRE(*str_opt == "hello world");
   }
   SECTION("Optional function returns nullopt if could not convert")
   {

--- a/test/test_object.cpp
+++ b/test/test_object.cpp
@@ -19,8 +19,8 @@ TEST_CASE("Object parsing works", "[Object]")
     REQUIRE(o.type == type);
     auto parsed = Object::parse(o);
     using prim_type = std::remove_reference_t<decltype(prim)>;
-    REQUIRE(std::holds_alternative<prim_type>(parsed));
-    REQUIRE(std::get<decltype(prim)>(parsed) == prim);
+    REQUIRE(parsed.has<prim_type>());
+    REQUIRE(parsed.get<decltype(prim)>() == prim);
   };
   SECTION("Primitives")
   {
@@ -33,8 +33,8 @@ TEST_CASE("Object parsing works", "[Object]")
     msgpack::object_handle oh = pack_unpack(s);
     const auto& o = oh.get();
     auto parsed = Object::parse(o);
-    REQUIRE(std::holds_alternative<QString>(parsed));
-    REQUIRE(std::get<QString>(parsed) == s.c_str());
+    REQUIRE(parsed.has<QString>());
+    REQUIRE(parsed.get<QString>() == s.c_str());
   }
   SECTION("Arrays")
   {
@@ -45,13 +45,13 @@ TEST_CASE("Object parsing works", "[Object]")
       REQUIRE(o.type == msgpack::type::ARRAY);
       REQUIRE(o.via.array.size == v.size());
       auto parsed = Object::parse(o);
-      REQUIRE(std::holds_alternative<ObjectArray>(parsed));
-      const auto& omap = std::get<ObjectArray>(parsed);
+      REQUIRE(parsed.has<ObjectArray>());
+      const auto& omap = parsed.get<ObjectArray>();
       for(std::size_t i = 0; i < omap.size(); ++i)
       {
         using val_type = decltype(v)::value_type;
-        REQUIRE(std::holds_alternative<val_type>(omap.at(i)));
-        REQUIRE(std::get<val_type>(omap.at(i)) == v.at(i));
+        REQUIRE(omap.at(i).has<val_type>());
+        REQUIRE(omap.at(i).get<val_type>() == v.at(i));
       }
     }
     {
@@ -63,13 +63,13 @@ TEST_CASE("Object parsing works", "[Object]")
       REQUIRE(o.type == msgpack::type::ARRAY);
       REQUIRE(o.via.array.size == v.size());
       auto parsed = Object::parse(o);
-      REQUIRE(std::holds_alternative<ObjectArray>(parsed));
-      const auto& omap = std::get<ObjectArray>(parsed);
+      REQUIRE(parsed.has<ObjectArray>());
+      const auto& omap = parsed.get<ObjectArray>();
       for(std::size_t i = 0; i < omap.size(); ++i)
       {
         using val_type = QString;
-        REQUIRE(std::holds_alternative<val_type>(omap.at(i)));
-        REQUIRE(std::get<val_type>(omap.at(i)) == QString::fromStdString(v.at(i)));
+        REQUIRE(omap.at(i).has<val_type>());
+        REQUIRE(omap.at(i).get<val_type>() == QString::fromStdString(v.at(i)));
       }
     }
   }
@@ -87,14 +87,14 @@ TEST_CASE("Object parsing works", "[Object]")
     REQUIRE(o.type == msgpack::type::MAP);
     REQUIRE(o.via.map.size == static_cast<uint32_t>(mp.size()));
     auto parsed = Object::parse(o);
-    REQUIRE(std::holds_alternative<ObjectMap>(parsed));
-    const auto& omap = std::get<ObjectMap>(parsed);
+    REQUIRE(parsed.has<ObjectMap>());
+    const auto& omap = parsed.get<ObjectMap>();
     REQUIRE(omap.size() == static_cast<uint32_t>(mp.size()));
     for(const auto& [key, val] : omap)
     {
       REQUIRE(mp.contains(key));
       // string type gets parsed to QString
-      REQUIRE(std::holds_alternative<QString>(val));
+      REQUIRE(val.has<QString>());
     }
   }
 }

--- a/test/test_object.cpp
+++ b/test/test_object.cpp
@@ -128,7 +128,7 @@ TEST_CASE("Extracting types from Object")
   SECTION("Optional function works")
   {
     Object o = QString("hello world");
-    auto qstr_opt = o.get_as<QString>();
+    auto qstr_opt = o.try_convert<QString>();
     REQUIRE(qstr_opt);
     REQUIRE(*qstr_opt == "hello world");
   }
@@ -136,7 +136,7 @@ TEST_CASE("Extracting types from Object")
   {
     Object o = std::uint64_t(5);
     // Optional returns nullopt if not convertible
-    auto str_opt = o.get_as<std::string>();
+    auto str_opt = o.try_convert<std::string>();
     REQUIRE(!str_opt);
   }
 }

--- a/test/test_object.cpp
+++ b/test/test_object.cpp
@@ -1,0 +1,144 @@
+#include <msgpack.hpp>
+#include "object.hpp"
+#include <catch2/catch.hpp>
+#include <iostream>
+
+template<typename T>
+msgpack::object_handle pack(const T& t)
+{
+  std::stringstream ss;
+  msgpack::pack(ss, t);
+  const auto& s = ss.str();
+  return msgpack::unpack(s.data(), s.size());
+}
+
+TEST_CASE("Object parsing works", "[Object]")
+{
+  const auto test_primitive = [&](auto prim, auto type) {
+    auto o = msgpack::object(prim);
+    REQUIRE(o.type == type);
+    auto parsed = Object::parse(o);
+    using prim_type = std::remove_reference_t<decltype(prim)>;
+    REQUIRE(std::holds_alternative<prim_type>(parsed));
+    REQUIRE(std::get<decltype(prim)>(parsed) == prim);
+  };
+  SECTION("Primitives")
+  {
+    test_primitive(uint64_t(5), msgpack::type::POSITIVE_INTEGER);
+    test_primitive(int64_t(-1), msgpack::type::NEGATIVE_INTEGER);
+    test_primitive(false, msgpack::type::BOOLEAN);
+    test_primitive(true, msgpack::type::BOOLEAN);
+    test_primitive(double(42.3), msgpack::type::FLOAT64);
+    std::string s = "hello";
+    auto oh = pack(s);
+    const auto& o = oh.get();
+    auto parsed = Object::parse(o);
+    REQUIRE(std::holds_alternative<QString>(parsed));
+    REQUIRE(std::get<QString>(parsed) == s.c_str());
+  }
+  SECTION("Arrays")
+  {
+    {
+      std::vector<int64_t> v {-1, -2, -3, -4};
+      std::stringstream ss;
+      msgpack::pack(ss, v);
+      auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
+      const auto& o = oh.get();
+      REQUIRE(o.type == msgpack::type::ARRAY);
+      REQUIRE(o.via.array.size == v.size());
+      auto parsed = Object::parse(o);
+      REQUIRE(std::holds_alternative<ObjectArray>(parsed));
+      const auto& omap = std::get<ObjectArray>(parsed);
+      for(std::size_t i = 0; i < omap.size(); ++i)
+      {
+        using val_type = decltype(v)::value_type;
+        REQUIRE(std::holds_alternative<val_type>(omap.at(i)));
+        REQUIRE(std::get<val_type>(omap.at(i)) == v.at(i));
+      }
+    }
+    {
+      std::vector<std::string> v {"hello", "hi"};
+      std::stringstream ss;
+      msgpack::pack(ss, v);
+      auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
+      const auto& o = oh.get();
+      REQUIRE(o.type == msgpack::type::ARRAY);
+      REQUIRE(o.via.array.size == v.size());
+      auto parsed = Object::parse(o);
+      REQUIRE(std::holds_alternative<ObjectArray>(parsed));
+      const auto& omap = std::get<ObjectArray>(parsed);
+      for(std::size_t i = 0; i < omap.size(); ++i)
+      {
+        using val_type = QString;
+        REQUIRE(std::holds_alternative<val_type>(omap.at(i)));
+        REQUIRE(std::get<val_type>(omap.at(i)) == QString::fromStdString(v.at(i)));
+      }
+    }
+  }
+  SECTION("Maps")
+  {
+    using string_map = std::unordered_map<std::string, std::string>;
+    string_map mp {
+      {"hello", "hi"},
+      {"here", "there"}
+    };
+    std::stringstream ss;
+    msgpack::pack(ss, mp);
+    auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
+    const auto& o = oh.get();
+    REQUIRE(o.type == msgpack::type::MAP);
+    REQUIRE(o.via.map.size == static_cast<uint32_t>(mp.size()));
+    auto parsed = Object::parse(o);
+    REQUIRE(std::holds_alternative<ObjectMap>(parsed));
+    const auto& omap = std::get<ObjectMap>(parsed);
+    REQUIRE(omap.size() == static_cast<uint32_t>(mp.size()));
+    for(const auto& [key, val] : omap)
+    {
+      REQUIRE(mp.contains(key));
+      // string type gets parsed to QString
+      REQUIRE(std::holds_alternative<QString>(val));
+    }
+  }
+}
+
+TEST_CASE("Extracting types from Object")
+{
+  SECTION("Implicit integer conversion")
+  {
+    Object o = std::uint64_t(5);
+    REQUIRE(o.has<std::uint64_t>());
+    // Should be able to convert to int(5)
+    try
+    {
+      int x = o;
+      REQUIRE(x == 5);
+    }
+    catch(...) { REQUIRE(!"Could not convert o = 5 to int."); }
+  }
+  SECTION("Get throws exception if it doesn't work")
+  {
+    Object o = std::uint64_t(5);
+    bool caught = false;
+    try
+    {
+      std::string s = o;
+      REQUIRE(false);
+    }
+    catch(...) { caught = true; }
+    REQUIRE(caught);
+  }
+  SECTION("Optional function works")
+  {
+    Object o = QString("hello world");
+    auto qstr_opt = o.get_as<QString>();
+    REQUIRE(qstr_opt);
+    REQUIRE(*qstr_opt == "hello world");
+  }
+  SECTION("Optional function returns nullopt if could not convert")
+  {
+    Object o = std::uint64_t(5);
+    // Optional returns nullopt if not convertible
+    auto str_opt = o.get_as<std::string>();
+    REQUIRE(!str_opt);
+  }
+}

--- a/test/test_object.cpp
+++ b/test/test_object.cpp
@@ -108,7 +108,7 @@ TEST_CASE("Extracting types from Object")
     // Should be able to convert to int(5)
     try
     {
-      int x = o;
+      int x = (int) o;
       REQUIRE(x == 5);
     }
     catch(...) { REQUIRE(!"Could not convert o = 5 to int."); }
@@ -119,7 +119,7 @@ TEST_CASE("Extracting types from Object")
     bool caught = false;
     try
     {
-      std::string s = o;
+      std::string s = (std::string) o;
       REQUIRE(false);
     }
     catch(...) { caught = true; }

--- a/test/test_object.cpp
+++ b/test/test_object.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 
 template<typename T>
-msgpack::object_handle pack(const T& t)
+msgpack::object_handle pack_unpack(const T& t)
 {
   std::stringstream ss;
   msgpack::pack(ss, t);
@@ -30,7 +30,7 @@ TEST_CASE("Object parsing works", "[Object]")
     test_primitive(true, msgpack::type::BOOLEAN);
     test_primitive(double(42.3), msgpack::type::FLOAT64);
     std::string s = "hello";
-    auto oh = pack(s);
+    msgpack::object_handle oh = pack_unpack(s);
     const auto& o = oh.get();
     auto parsed = Object::parse(o);
     REQUIRE(std::holds_alternative<QString>(parsed));
@@ -40,9 +40,7 @@ TEST_CASE("Object parsing works", "[Object]")
   {
     {
       std::vector<int64_t> v {-1, -2, -3, -4};
-      std::stringstream ss;
-      msgpack::pack(ss, v);
-      auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
+      auto oh = pack_unpack(v);
       const auto& o = oh.get();
       REQUIRE(o.type == msgpack::type::ARRAY);
       REQUIRE(o.via.array.size == v.size());

--- a/test/test_object.cpp
+++ b/test/test_object.cpp
@@ -2,6 +2,7 @@
 #include "object.hpp"
 #include <catch2/catch.hpp>
 #include <iostream>
+#include <sstream>
 
 template<typename T>
 msgpack::object_handle pack_unpack(const T& t)

--- a/test/test_object_deserialization_msgpack.cpp
+++ b/test/test_object_deserialization_msgpack.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Object correctly deserialies from msgpack")
     std::string_view sv(sbuf.data(), sbuf.size() - 1);
     std::size_t offset = 0;
     Object o = Object::from_msgpack(sv, offset);
-    REQUIRE(o.has_err());
+    REQUIRE(o.is_err());
     REQUIRE(o.get<Error>().msg == "Insufficient Bytes");
   }
 }

--- a/test/test_object_deserialization_msgpack.cpp
+++ b/test/test_object_deserialization_msgpack.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Object correctly deserialies from msgpack")
     const auto& arr = parsed.get<ObjectArray>();
     for(std::size_t i = 0; i < arr.size(); ++i)
     {
-      auto opt = arr[i].get_as<decltype(x)::value_type>();
+      auto opt = arr[i].try_convert<decltype(x)::value_type>();
       REQUIRE(opt);
       REQUIRE(*opt == x[i]);
     }

--- a/test/test_object_deserialization_msgpack.cpp
+++ b/test/test_object_deserialization_msgpack.cpp
@@ -24,4 +24,18 @@ TEST_CASE("Object correctly deserialies from msgpack")
       REQUIRE(*opt == x[i]);
     }
   }
+  SECTION("Error parsing")
+  {
+    msgpack::sbuffer sbuf;
+    std::vector<std::uint64_t> x {1, 2, 3, 4, 5, 6};
+    msgpack::pack(sbuf, x);
+    // Reducing the size of the string view by 1
+    // causes it to not read the "array end" message,
+    // causing an error (it tries to read more elements).
+    std::string_view sv(sbuf.data(), sbuf.size() - 1);
+    std::size_t offset = 0;
+    Object o = Object::from_msgpack(sv, offset);
+    REQUIRE(o.has_err());
+    REQUIRE(o.get<Error>().msg == "Insufficient Bytes");
+  }
 }

--- a/test/test_object_deserialization_msgpack.cpp
+++ b/test/test_object_deserialization_msgpack.cpp
@@ -1,0 +1,27 @@
+#include <catch2/catch.hpp>
+#include "object.hpp"
+#include <msgpack.hpp>
+#include <cstdint>
+
+TEST_CASE("Object correctly deserialies from msgpack")
+{
+  SECTION("Deserializing an array of u64s")
+  {
+    msgpack::sbuffer pack_buf;
+    std::vector<std::uint64_t> x {5, 2, 3, 4, 6};
+    msgpack::pack(pack_buf, x);
+    std::string_view sv {pack_buf.data(), pack_buf.size()};
+    std::size_t offset = 0;
+    auto parsed = Object::from_msgpack(sv, offset);
+    REQUIRE(offset == sv.size()); // Only one object
+    REQUIRE(parsed.has<ObjectArray>());
+    REQUIRE(parsed.array()->size() == x.size());
+    const auto& arr = parsed.get<ObjectArray>();
+    for(std::size_t i = 0; i < arr.size(); ++i)
+    {
+      auto opt = arr[i].get_as<decltype(x)::value_type>();
+      REQUIRE(opt);
+      REQUIRE(*opt == x[i]);
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,7 @@
     "qt5-base",
     "qt5-svg",
     "boost-process",
+    "boost-container",
     "catch2"
   ]
 }


### PR DESCRIPTION
Most of the code that handles Neovim UI events have a function signature of `(const msgpack::object*, std::uint32_t`). This isn't really ideal.
This PR introduces an Object class that serves as the deserialization target. Internally the Object type is a variant that holds some basic types, but it can also hold arrays of Object and a map from a string to an Object.
When the Nvim class reads data, the Object class deserializes it using `Object::from_msgpack`. Insufficient bytes and parse errors don't throw exceptions, but instead return an Object containing an Error.
Objects are value types, and so now the data is just `std::move`'d between threads.
Also, instead of taking a ptr and size, function parameters are now passed an `std::span<const Object>` which is a non-owning view to the objects.
The only problem is that at least on my system, parsing an Object from a messagepack-encoded string is slower than using `msgpack::unpack` - around 6x slower, but it still takes less than one millisecond.