### PR TITLE
Windows: Fix areas not being drawn

### DIFF
--- a/src/platform/windows/direct2dpaintgrid.cpp
+++ b/src/platform/windows/direct2dpaintgrid.cpp
@@ -28,6 +28,7 @@ void D2DPaintGrid::initialize_context()
 {
   editor_area->create_context(&context, &bitmap, 0, 0);
   context->SetTarget(bitmap);
+  context->SetAntialiasMode(D2D1_ANTIALIAS_MODE_ALIASED);
 }
 
 void D2DPaintGrid::initialize_cache()
@@ -98,7 +99,6 @@ void D2DPaintGrid::process_events()
   u32 bg = editor_area->default_bg().rgb();
   context->CreateSolidColorBrush(d2color(fg), &fg_brush);
   context->CreateSolidColorBrush(d2color(bg), &bg_brush);
-  auto&& [font_width, font_height] = editor_area->font_dimensions();
   while(!evt_q.empty())
   {
     const auto& evt = evt_q.front();
@@ -106,7 +106,7 @@ void D2DPaintGrid::process_events()
     {
       case PaintKind::Clear:
       {
-        d2rect r = {0, 0, cols * font_width, rows * font_height};
+        d2rect r = source_rect();
         bg_brush->SetColor(d2color(bg));
         context->FillRectangle(r, bg_brush);
         break;
@@ -133,7 +133,7 @@ static void draw_text_decorations(
   D2D1_POINT_2F seq_end,
   float font_width,
   float font_height,
-  ID2D1SolidColorBrush* brush
+  ID2D1SolidColorBrush& brush
 )
 {
   using d2pt = D2DPaintGrid::d2pt;
@@ -146,7 +146,7 @@ static void draw_text_decorations(
         - std::round(font_height * 0.1f)
         - (line_thickness / 2.f);
       context->DrawLine(
-        {seq_start.x, line_mid}, {seq_end.x, line_mid}, brush, line_thickness
+        {seq_start.x, line_mid}, {seq_end.x, line_mid}, &brush, line_thickness
       );
       break;
     }
@@ -155,7 +155,7 @@ static void draw_text_decorations(
       float line_thickness = 1.0f;
       float line_mid = seq_start.y + (font_height - line_thickness) / 2.f;
       context->DrawLine(
-        {seq_start.x, line_mid}, {seq_end.x, line_mid}, brush, line_thickness
+        {seq_start.x, line_mid}, {seq_end.x, line_mid}, &brush, line_thickness
       );
       break;
     }
@@ -169,7 +169,7 @@ static void draw_text_decorations(
       for(float x = seq_start.x + inc;; x += inc)
       {
         d2pt cur_pos = {std::min(x, seq_end.x), seq_end.y - (line_height * top)};
-        context->DrawLine(prev_pos, cur_pos, brush, line_thickness);
+        context->DrawLine(prev_pos, cur_pos, &brush, line_thickness);
         prev_pos = cur_pos;
         top = !top;
         if (x >= seq_end.x) break;
@@ -178,6 +178,113 @@ static void draw_text_decorations(
     }
     default: break;
   }
+}
+
+void D2DPaintGrid::draw_text(
+  ID2D1RenderTarget& target,
+  const QString& text,
+  const Color& fg,
+  const Color& sp,
+  const FontOptions font_opts,
+  D2D1_POINT_2F top_left,
+  D2D1_POINT_2F bot_right,
+  float font_width,
+  float font_height,
+  ID2D1SolidColorBrush& fg_brush,
+  IDWriteTextFormat* text_format,
+  bool clip
+)
+{
+  if (clip)
+  {
+    target.PushAxisAlignedClip({
+      top_left.x, top_left.y, bot_right.x, bot_right.y
+    }, D2D1_ANTIALIAS_MODE_ALIASED);
+  }
+  fg_brush.SetColor(d2color(fg.to_uint32()));
+  using key_type = decltype(layout_cache)::key_type;
+  IDWriteTextLayout* old_text_layout = nullptr;
+  IDWriteTextLayout1* text_layout = nullptr;
+  key_type key = {text, font_opts};
+  auto objptr = layout_cache.get(key);
+  if (objptr) text_layout = *objptr;
+  else
+  {
+    HRESULT hr;
+    auto* factory = editor_area->dwrite_factory();
+    hr = factory->CreateTextLayout(
+      (LPCWSTR) text.utf16(),
+      text.size(),
+      text_format,
+      // Sometimes the text clips weirdly & adding
+      // to the width solves it. It's probably because
+      // the text is just a little wider than the max width we set
+      // so we increase the max width by a little here.
+      bot_right.x - top_left.x + 1000.f,
+      bot_right.y - top_left.y,
+      &old_text_layout
+    );
+    if (FAILED(hr)) return;
+    // IDWriteTextLayout1 can set char spacing
+    hr = old_text_layout->QueryInterface(&text_layout);
+    if (FAILED(hr)) { SafeRelease(&old_text_layout); return; }
+    DWRITE_TEXT_RANGE text_range {0, (UINT32) text.size()};
+    auto charspace = editor_area->charspacing();
+    if (charspace)
+    {
+      text_layout->SetCharacterSpacing(0, float(charspace), 0, text_range);
+    }
+    if (font_opts & FontOpts::Italic)
+    {
+      text_layout->SetFontStyle(DWRITE_FONT_STYLE_ITALIC, text_range);
+    }
+    if (font_opts & FontOpts::Bold)
+    {
+      text_layout->SetFontWeight(DWRITE_FONT_WEIGHT_BOLD, text_range);
+    }
+    layout_cache.put(key, text_layout);
+  }
+  auto offset = float(editor_area->linespacing()) / 2.f;
+  D2D1_POINT_2F text_pt = {top_left.x, top_left.y + offset};
+  target.DrawTextLayout(
+    text_pt,
+    text_layout,
+    &fg_brush,
+    D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT
+  );
+  fg_brush.SetColor(D2D1::ColorF(sp.to_uint32()));
+  SafeRelease(&old_text_layout);
+  const auto draw_path = [&](const FontOpts fo) {
+    draw_text_decorations(
+      context, fo, top_left, bot_right, font_width, font_height, fg_brush
+    );
+  };
+  if (font_opts & FontOpts::Underline) draw_path(FontOpts::Underline);
+  if (font_opts & FontOpts::Undercurl) draw_path(FontOpts::Undercurl);
+  if (font_opts & FontOpts::Strikethrough) draw_path(FontOpts::Strikethrough);
+  if (clip) target.PopAxisAlignedClip();
+}
+
+void D2DPaintGrid::draw_bg(
+  ID2D1RenderTarget& target,
+  const Color& bg,
+  D2D1_POINT_2F top_left,
+  D2D1_POINT_2F bot_right,
+  ID2D1SolidColorBrush& brush
+)
+{
+  brush.SetColor(D2D1::ColorF(bg.to_uint32()));
+  target.FillRectangle({top_left.x, top_left.y, bot_right.x, bot_right.y}, &brush);
+}
+
+void D2DPaintGrid::draw_bg(
+  ID2D1RenderTarget& target,
+  const Color& bg,
+  D2D1_RECT_F rect,
+  ID2D1SolidColorBrush& brush
+)
+{
+  draw_bg(target, bg, {rect.left, rect.top}, {rect.right, rect.bottom}, brush);
 }
 
 void D2DPaintGrid::draw_text_and_bg(
@@ -194,68 +301,13 @@ void D2DPaintGrid::draw_text_and_bg(
   ID2D1SolidColorBrush* bg_brush
 )
 {
-  using key_type = decltype(layout_cache)::key_type;
-  IDWriteTextLayout* old_text_layout = nullptr;
-  IDWriteTextLayout1* text_layout = nullptr;
-  key_type key = {buf, attr.font_opts};
-  auto objptr = layout_cache.get(key);
-  if (objptr) text_layout = *objptr;
-  else
-  {
-    HRESULT hr;
-    auto* factory = editor_area->dwrite_factory();
-    hr = factory->CreateTextLayout(
-      (LPCWSTR) buf.utf16(),
-      buf.size(),
-      text_format,
-      // Sometimes the text clips weirdly & adding
-      // to the width solves it. It's probably because
-      // the text is just a little wider than the max width we set
-      // so we increase the max width by a little here.
-      end.x - start.x + 1000.f,
-      end.y - start.y,
-      &old_text_layout
-    );
-    if (FAILED(hr)) return;
-    // IDWriteTextLayout1 can set char spacing
-    hr = old_text_layout->QueryInterface(&text_layout);
-    if (FAILED(hr)) { SafeRelease(&old_text_layout); return; }
-    DWRITE_TEXT_RANGE text_range {0, (UINT32) buf.size()};
-    auto charspace = editor_area->charspacing();
-    if (charspace)
-    {
-      text_layout->SetCharacterSpacing(0, float(charspace), 0, text_range);
-    }
-    if (attr.italic())
-    {
-      text_layout->SetFontStyle(DWRITE_FONT_STYLE_ITALIC, text_range);
-    }
-    if (attr.bold())
-    {
-      text_layout->SetFontWeight(DWRITE_FONT_WEIGHT_BOLD, text_range);
-    }
-    layout_cache.put(key, text_layout);
-  }
   auto [fg, bg, sp] = attr.fg_bg_sp(fallback);
-  fg_brush->SetColor(D2D1::ColorF(fg.to_uint32()));
-  bg_brush->SetColor(D2D1::ColorF(bg.to_uint32()));
-  context->FillRectangle({start.x, start.y, end.x, end.y}, bg_brush);
-  auto offset = float(editor_area->linespacing()) / 2.f;
-  D2D1_POINT_2F text_pt = {start.x, start.y + offset};
-  context->DrawTextLayout(
-    text_pt,
-    text_layout,
-    fg_brush,
-    D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT
+  auto bg_tl = D2D1::Point2F(std::floor(start.x), start.y);
+  draw_bg(*context, bg, bg_tl, end, *bg_brush);
+  draw_text(
+    *context, buf, fg, sp, attr.font_opts, start, end,
+    font_width, font_height, *fg_brush, text_format
   );
-  SafeRelease(&old_text_layout);
-  fg_brush->SetColor(D2D1::ColorF(sp.to_uint32()));
-  const auto draw_path = [&](const FontOpts fo) {
-    draw_text_decorations(context, fo, start, end, font_width, font_height, fg_brush);
-  };
-  if (attr.font_opts & FontOpts::Underline) draw_path(FontOpts::Underline);
-  if (attr.font_opts & FontOpts::Undercurl) draw_path(FontOpts::Undercurl);
-  if (attr.font_opts & FontOpts::Strikethrough) draw_path(FontOpts::Strikethrough);
 }
 
 void D2DPaintGrid::draw(
@@ -265,6 +317,7 @@ void D2DPaintGrid::draw(
   ID2D1SolidColorBrush* bg_brush
 )
 {
+  auto target_size = context->GetSize();
   const auto& fonts = editor_area->fallback_list();
   //const int start_x = r.left(), end_x = r.right();
   const int start_y = r.top(), end_y = r.bottom();
@@ -277,7 +330,7 @@ void D2DPaintGrid::draw(
   const auto& def_clrs = s->default_colors_get();
   u32 cur_font_idx = 0;
   const auto get_pos = [&](int x, int y, int num_chars) {
-    d2pt tl = {std::floor(x * font_width), y * font_height};
+    d2pt tl = {x * font_width, y * font_height};
     d2pt br = {(x + num_chars) * font_width, (y + 1) * font_height};
     return std::pair {tl, br};
   };
@@ -293,7 +346,7 @@ void D2DPaintGrid::draw(
   };
   for(int y = start_y; y <= end_y && y < rows; ++y)
   {
-    d2pt end = {context->GetSize().width, (y + 1) * font_height};
+    d2pt end = {target_size.width, (y + 1) * font_height};
     int prev_hl_id = 0;
     if (y * cols + (cols - 1) < (int) area.size())
     {
@@ -498,7 +551,6 @@ void D2DPaintGrid::draw_cursor(ID2D1RenderTarget *target, const Cursor &cursor)
 {
   const auto& text_formats = editor_area->fallback_list();
   const HLState* hl = editor_area->hl_state();
-  const auto& def_clrs = hl->default_colors_get();
   const auto [font_width, font_height] = editor_area->font_dimensions();
   const auto pos_opt = cursor.pos();
   if (!pos_opt) return;
@@ -509,32 +561,28 @@ void D2DPaintGrid::draw_cursor(ID2D1RenderTarget *target, const Cursor &cursor)
   float scale_factor = 1.0f;
   if (gc.double_width) scale_factor = 2.0f;
   const CursorRect rect = *cursor.rect(font_width, font_height, scale_factor);
-  ID2D1SolidColorBrush* bg_brush = nullptr;
-  HLAttr attr = hl->attr_for_id(rect.hl_id);
-  auto [fg, bg] = hl->colors_for(attr);
-  target->CreateSolidColorBrush(D2D1::ColorF(bg.to_uint32()), &bg_brush);
+  ID2D1SolidColorBrush* brush = nullptr;
+  const HLAttr& attr = hl->attr_for_id(rect.hl_id);
+  auto [fg, bg, sp] = attr.fg_bg_sp(hl->default_colors_get());
+  target->CreateSolidColorBrush(D2D1::ColorF(bg.to_uint32()), &brush);
   const QRectF& r = rect.rect;
   auto fill_rect = D2D1::RectF(r.left(), r.top(), r.right(), r.bottom());
-  target->PushAxisAlignedClip(fill_rect, D2D1_ANTIALIAS_MODE_ALIASED);
-  target->FillRectangle(fill_rect, bg_brush);
-  target->PopAxisAlignedClip();
+  // Draw cursor background
+  draw_bg(*target, bg, fill_rect, *brush);
   if (rect.should_draw_text)
   {
-    ID2D1SolidColorBrush* fg_brush = nullptr;
-    target->CreateSolidColorBrush(D2D1::ColorF(fg.to_uint32()), &fg_brush);
+    fill_rect.right = std::max(fill_rect.right, fill_rect.left + font_width);
     // If the rect exists, the pos must exist as well.
     auto font_idx = editor_area->font_for_ucs(gc.ucs);
     assert(font_idx < text_formats.size());
-    if (rect.hl_id == 0) attr.reverse = true;
     const auto start = D2D1::Point2F(fill_rect.left, fill_rect.top);
     const auto end = D2D1::Point2F(fill_rect.right, fill_rect.bottom);
-    draw_text_and_bg(
-      target, gc.text, attr, def_clrs, start, end, font_width, font_height,
-      text_formats[font_idx], fg_brush, bg_brush
+    draw_text(
+      *target, gc.text, fg, sp, attr.font_opts, start, end,
+      font_width, font_height, *brush, text_formats[font_idx], true
     );
-    SafeRelease(&fg_brush);
   }
-  SafeRelease(&bg_brush);
+  SafeRelease(&brush);
 }
 
 D2DPaintGrid::~D2DPaintGrid()

--- a/src/platform/windows/direct2dpaintgrid.hpp
+++ b/src/platform/windows/direct2dpaintgrid.hpp
@@ -48,6 +48,8 @@ public:
   using d2pt = D2D1_POINT_2F;
   using d2rect = D2D1_RECT_F;
   using d2color = D2D1::ColorF;
+  using cache_type =
+    LRUCache<QPair<QString, FontOptions>, IDWriteTextLayout1*, TextLayoutDeleter>;
 public:
   template<typename... GridBaseArgs>
   D2DPaintGrid(WinEditorArea* wea, GridBaseArgs... args)
@@ -109,8 +111,7 @@ private:
   using FontOptions = decltype(HLAttr::font_opts);
   /// A lot of time is spent text shaping, we cache the created text
   /// layouts
-  LRUCache<QPair<QString, FontOptions>, IDWriteTextLayout1*, TextLayoutDeleter>
-  layout_cache;
+  cache_type layout_cache;
   /// Update the size of the bitmap to match the
   /// grid size
   void update_bitmap_size();
@@ -146,6 +147,33 @@ private:
     IDWriteTextFormat* text_format,
     ID2D1SolidColorBrush* fg_brush,
     ID2D1SolidColorBrush* bg_brush
+  );
+  void draw_text(
+    ID2D1RenderTarget& target,
+    const QString& text,
+    const Color& fg,
+    const Color& sp,
+    const FontOptions font_opts,
+    D2D1_POINT_2F top_left,
+    D2D1_POINT_2F bot_right,
+    float font_width,
+    float font_height,
+    ID2D1SolidColorBrush& fg_brush,
+    IDWriteTextFormat* text_format,
+    bool clip = false
+  );
+  void draw_bg(
+    ID2D1RenderTarget& target,
+    const Color& bg,
+    D2D1_POINT_2F top_left,
+    D2D1_POINT_2F bot_right,
+    ID2D1SolidColorBrush& brush
+  );
+  void draw_bg(
+    ID2D1RenderTarget& target,
+    const Color& bg,
+    D2D1_RECT_F rect,
+    ID2D1SolidColorBrush& brush
   );
   /// Returns a copy of src.
   /// NOTE: Must be released.


### PR DESCRIPTION
Some commits were added on the main branch but they have some issues with the text shifting around / cursor overlapping characters.
This pr should fix this issue properly.
Heres what it looks like if you change the color scheme (it goes away when the cursor moves around)
![nvui_undrawn](https://user-images.githubusercontent.com/64917719/139143575-207f7af2-f264-4734-90ab-c82d305d24ea.png)
