### PR TITLE
Fix ordering of floating windows

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -399,7 +399,7 @@ void EditorArea::msg_set_pos(std::span<NeovimObj> objs)
     //auto sep_char = arr.ptr[3].as<QString>();
     if (GridBase* grid = find_grid(grid_num))
     {
-      grid->float_pos(grid->x, row);
+      grid->set_pos(grid->x, row);
       move_to_top(grid);
     }
   }

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -572,43 +572,11 @@ protected:
     }
   }
   /// Sorts grids in order of their z index.
-  void sort_grids_by_z_index()
-  {
-    std::sort(grids.begin(), grids.end(), [](const auto& g1, const auto& g2) {
-      return g1->z_index < g2->z_index;
-    });
-  }
+  void sort_grids_by_z_index();
   /// Returns an integer identifier for the window.
   /// Translated version of
   /// https://github.com/neovim/go-client/blob/e3638e2a1819d9a5fc7238a89dd3ad5c48abc5ab/nvim/nvim.go#L723
-  std::int64_t get_win(const NeovimExt& ext)
-  {
-    using namespace std;
-    vector<uint8_t> data;
-    for(const auto& c : ext.data) data.push_back(static_cast<uint8_t>(c));
-    const auto size = ext.data.size();
-    if (size == 1 && data[0] <= 0x7f) return (int) data[0];
-    else if (size == 1 && data[0] >= 0xe0)
-    {
-      return int8_t(data[0]);
-    }
-    else if (size == 2 && data[0] == 0xcc) return (int) data[1];
-    else if (size == 2 && data[0] == 0xd0) return int8_t(data[1]);
-    else if (size == 3 && data[0] == 0xcd)
-    {
-      return u16(data[2]) | u16(data[1]) << 8;
-    }
-    else if (size == 3 && data[0] == 0xd1)
-    {
-      return int16_t(uint16_t(data[2])) | uint16_t(data[1]) << 8;
-    }
-    else if (size == 5 && data[0] == 0xce)
-    {
-      return u32(data[4] | u32(data[3]) << 8
-           | u32(data[2]) << 16 | u32(data[1]) << 24);
-    }
-    return numeric_limits<int>::min();
-  }
+  std::int64_t get_win(const NeovimExt& ext);
 public slots:
   /**
    * Handle a window resize.

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -6,6 +6,31 @@
 scalers::time_scaler GridBase::scroll_scaler = scalers::oneminusexpo2negative10;
 scalers::time_scaler GridBase::move_scaler = scalers::oneminusexpo2negative10;
 
+bool GridBase::FloatOrderInfo::operator<(const FloatOrderInfo& other) const
+{
+  return zindex < other.zindex || x < other.x || y < other.y;
+}
+
+bool GridBase::operator<(const GridBase& other) const noexcept
+{
+  if (!is_float() && other.is_float())
+  {
+    return true;
+  }
+  else if (is_float() && !other.is_float())
+  {
+    return false;
+  }
+  else if (is_float() && other.is_float())
+  {
+    return float_ordering_info < other.float_ordering_info;
+  }
+  else
+  {
+    return z_index < other.z_index;
+  }
+}
+
 grid_char GridChar::grid_char_from_str(const std::string& s)
 {
   return QString::fromStdString(s);

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -156,6 +156,14 @@ class GridBase : public QObject
 {
   Q_OBJECT
 public:
+  /// For floating window ordering
+  struct FloatOrderInfo
+  {
+    bool operator<(const FloatOrderInfo& other) const;
+    int zindex;
+    double x;
+    double y;
+  };
   using u16 = std::uint16_t;
   using u32 = std::uint32_t;
   using u64 = std::uint64_t;
@@ -276,7 +284,7 @@ public:
     viewport = vp;
   }
   bool is_float() const { return is_float_grid; }
-  void set_floating(bool f) { is_float_grid = f; }
+  void set_floating(bool f) noexcept { is_float_grid = f; }
   void win_pos(u16 x, u16 y)
   {
     set_pos(x, y);
@@ -287,6 +295,11 @@ public:
     set_pos(x, y);
     set_floating(true);
   }
+  void set_float_ordering_info(int zindex, const QPointF& p) noexcept
+  {
+    float_ordering_info = {zindex, p.x(), p.y()};
+  }
+  bool operator<(const GridBase& other) const noexcept;
 public:
   u16 x;
   u16 y;
@@ -300,6 +313,7 @@ public:
   std::queue<PaintEventItem> evt_q;
   Viewport viewport;
   bool is_float_grid = false;
+  FloatOrderInfo float_ordering_info;
   /// Not used in GridBase (may not even be used at all
   /// if animations are not supported/enabled by the rendering
   /// grid).


### PR DESCRIPTION
Should fix #50.
Since multiple floating windows can have the same `zindex` value for some reason, we use the row and column to check which windows to draw first (only when they have the same z index, otherwise windows with lower z index are drawn first).
When one or more windows have the same `zindex`, they get drawn in order of which row and column they appear on (lower (row, col) = drawn before), seems to work