### PR TITLE
Add config for UI & Window settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ file(GLOB SOURCES
   src/qeditor.hpp
   src/qeditor.cpp
   resources.qrc
+  src/config.hpp
+  src/config.cpp
 )
 if (WIN32)
   message("Windows detected.")
@@ -96,11 +98,10 @@ if (WIN32)
   list(APPEND SOURCES ${WINONLYSOURCES})
 endif()
 find_package(Boost COMPONENTS filesystem thread REQUIRED)
-list(APPEND SOURCES "src/main.cpp")
 if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Release")
-  add_executable(nvui WIN32 "assets/icons/desktop/neovim_icon.rc" ${SOURCES})
+  add_executable(nvui WIN32 "assets/icons/desktop/neovim_icon.rc" "src/main.cpp" ${SOURCES})
 else()
-  add_executable(nvui ${SOURCES})
+  add_executable(nvui "src/main.cpp" ${SOURCES})
 endif()
 target_link_libraries(nvui PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Svg)
 target_link_libraries(nvui PRIVATE fmt::fmt)
@@ -130,46 +131,7 @@ endif()
 if(BUILD_TESTS)
   find_package(Catch2 CONFIG REQUIRED)
   file(GLOB TEST_SOURCES
-    src/titlebar.hpp
-    src/titlebar.cpp
-    src/utils.hpp
-    src/nvim.hpp
-    src/nvim.cpp
-    src/window.hpp
-    src/window.cpp
-    src/hlstate.hpp
-    src/hlstate.cpp
-    src/cursor.hpp
-    src/cursor.cpp
-    test/*.cpp
-    src/popupmenu.hpp
-    src/popupmenu.cpp
-    src/cmdline.hpp
-    src/cmdline.cpp
-    src/font.hpp
-    src/grid.cpp
-    src/grid.hpp
-    src/object.hpp
-    src/object.cpp
-    src/decide_renderer.hpp
-    src/input.cpp
-    src/input.hpp
-    src/scalers.hpp
-    src/lru.hpp
-    src/qpaintgrid.hpp
-    src/qpaintgrid.cpp
-    src/animation.hpp
-    src/animation.cpp
-    src/mouse.hpp
-    src/types.hpp
-    src/fontdesc.hpp
-    src/editor_base.cpp
-    src/editor_base.hpp
-    src/qt_editorui_base.cpp
-    src/qt_editorui_base.hpp
-    src/nvim_utils.hpp
-    src/qeditor.hpp
-    src/qeditor.cpp
+    test/test_*.cpp
   )
   if (WIN32)
     file(GLOB WINONLYTESTSOURCES

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,38 @@
+#include "config.hpp"
+#include "utils.hpp"
+
+std::unique_ptr<QSettings> Config::settings_ptr = nullptr;
+
+void Config::init()
+{
+  const auto ini_path = normalize_path("nvui-config.ini");
+  if (!settings_ptr)
+  {
+    settings_ptr = std::make_unique<QSettings>(ini_path, QSettings::IniFormat);
+  }
+}
+
+QVariant Config::get(const QString& key, const QVariant& default_val)
+{
+  return settings_ptr->value(key, default_val);
+}
+
+void Config::set(const QString& key, const QVariant& value)
+{
+  settings_ptr->setValue(key, value);
+}
+
+bool Config::is_set(const QString& key)
+{
+  return settings_ptr->contains(key);
+}
+
+void Config::remove_key(const QString& key)
+{
+  settings_ptr->remove(key);
+}
+
+void Config::clear()
+{
+  settings_ptr->clear();
+}

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,0 +1,28 @@
+#ifndef NVUI_SETTINGS_HPP
+#define NVUI_SETTINGS_HPP
+
+#include <QSettings>
+
+// External settings that aren't really runtime-configurable.
+// This means things like default UI settings (multigrid being the biggest
+// one, since it is not changeable at runtime), as well as startup
+// position and size.
+class Config
+{
+public:
+  // Initialize config (load config file)
+  // This must be done AFTER the QApplication is created
+  // For a config file to be loaded it must be in the executable directory
+  // under the name "nvui-config.ini".
+  static void init();
+  // init() MUST be called before the following functions
+  static QVariant get(const QString& key, const QVariant& def_val = QVariant());
+  static void set(const QString& key, const QVariant& value);
+  static bool is_set(const QString& key);
+  static void remove_key(const QString& key);
+  static void clear();
+private:
+  static std::unique_ptr<QSettings> settings_ptr;
+};
+
+#endif // NVUI_SETTINGS_HPP

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -48,6 +48,7 @@ public:
     std::unordered_map<std::string, bool> capabilities,
     int width,
     int height,
+    bool size_set,
     bool custom_titlebar,
     QWidget* parent = nullptr
   );
@@ -72,6 +73,11 @@ public slots:
    */
   void connect_editor_signals(EditorType&);
 private:
+  /// Save current window state and settings.
+  void save_state();
+  /// Load saved config state, if it exists.
+  /// Returns true if any values were set.
+  bool load_config();
   /**
    * Disable the frameless window.
    * The window should be in frameless mode,


### PR DESCRIPTION
Lives under "nvui-config.ini" in the application executable directory.
Right now it stores window settings (position, size, fullscreen, maximized, frameless), as well as some ext-UI options (multigrid, cmdline, popupmenu). This means that if you're running nvui with a bunch of `--ext_*` arguments, they will be remembered after the first time. As an example, if you run nvui with `nvui --ext_multigrid --ext_popupmenu --ext_cmdline`, the options will be remembered and the next time you only need to run `nvui` and the external features will be enabled. You can override this by re-specifying the options with different values.
