### PR TITLE
Use font metrics for the letter 'M' instead of 'W'

### DIFF
--- a/src/platform/windows/d2deditor.cpp
+++ b/src/platform/windows/d2deditor.cpp
@@ -324,7 +324,7 @@ void D2DEditor::update_font_metrics()
 {
   if (dw_formats.empty()) return;
   auto format = dw_formats.front().reg.Get();
-  auto metrics = metrics_for(L"W", dw_factory.Get(), format);
+  auto metrics = metrics_for(L"M", dw_factory.Get(), format);
   float font_width = metrics.width + charspacing();
   float font_height = std::ceil(metrics.height + linespacing());
   set_font_dimensions(font_width, font_height);

--- a/src/qeditor.cpp
+++ b/src/qeditor.cpp
@@ -195,7 +195,7 @@ void QEditor::update_font_metrics()
   QFontMetricsF metrics {first_font};
   float combined_height = std::max(metrics.height(), metrics.lineSpacing());
   double font_height = combined_height + linespacing();
-  constexpr QChar any_char = 'W';
+  constexpr QChar any_char = 'M';
   double font_width = metrics.horizontalAdvance(any_char) + charspace;
   for(auto& f : fonts)
   {


### PR DESCRIPTION
Fixes font display quirks and inconsistencies.

**Examples**
- Font: JetBrains Mono, height 11
Before:
(The letter "m" looks squished and hard to discern)
![screenshot_20220226-135125](https://user-images.githubusercontent.com/31634638/155835562-c7e6f36d-b571-40c6-8f06-bc1fa2d2937c.png)
With this PR:
![screenshot_20220226-135154](https://user-images.githubusercontent.com/31634638/155835559-d5436d67-512e-4454-ae45-7155cafc734e.png)

- Font: JetBrainsMono Nerd Font, height 11
Before:
(Some letters, like 'e', 't', 'i', 'p' have relatively shorter heights)
![screenshot_20220226-135930](https://user-images.githubusercontent.com/31634638/155835699-c551a26e-5601-4867-9a3b-69e7a35bc13f.png)
With this PR:
![screenshot_20220226-135953](https://user-images.githubusercontent.com/31634638/155835697-b11c5358-1e21-4998-931a-333f82975bef.png)

Inspired by this neovide [commit](https://github.com/neovide/neovide/commit/b0ec20be4a8b044db6a3584d9dc98970cec0b0ee).

