### PR TITLE
fix: blurry text on high-dpi display

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,7 @@ bool is_executable(std::string_view path)
 int main(int argc, char** argv)
 {
   QCoreApplication::setApplicationName("nvui");
+  QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
   QApplication app {argc, argv};
   Config::init();
   const auto args = get_args(argc, argv);


### PR DESCRIPTION
Hey
I was trying out this app and found fonts were showing up blurry (I am using kde with scaling), I think the issue was the Qt auto scaling just scales the font pixels rather than the point size hence the edges don't look quite right.

Anyway this just disables Qt's own scaling, I'm pretty sure the fonts are still scaled up according to my desktop scaling as the text size looks the same between this and main. 

I have not tested this on anything but my machine


before: ![before_nvui-dpiscaling](https://user-images.githubusercontent.com/46329225/167202965-f38c91f3-b30b-4132-b8ae-9edd2dd2f5a0.png)

after: ![after_nvui-dpiscaling](https://user-images.githubusercontent.com/46329225/167202998-12cd1b65-245e-40a5-b9a0-fb0730925a6f.png)

