### PR TITLE
Fix issue #147: Send <C-^> instead of <^>

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -302,7 +302,7 @@ static std::string convertKey(const QKeyEvent& ev) noexcept
     const Qt::KeyboardModifiers modNoShiftMeta = mod
       & Qt::KeyboardModifier::ShiftModifier
       & ~d_mod();
-    return key_mod_str(modNoShiftMeta, "^");
+    return key_mod_str(modNoShiftMeta, "C-^");
   }
 
   if (text == "\\")


### PR DESCRIPTION
Fix #147 Before this commit <C-^> was read as <^> by nvui which is not a valid mapping, this commit fixes that.